### PR TITLE
COPY instead of ADD + Environment variable SITEPATH

### DIFF
--- a/sitecore/8.2 rev. 170407/Dockerfile
+++ b/sitecore/8.2 rev. 170407/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ADD *.zip .
+COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item 'C:\Sitecore*.zip' -Force; `
@@ -13,8 +13,8 @@ RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item -Path 'C:\Sitecore\Data\logs' -Recurse -Force; `
     Remove-Item -Path 'C:\Sitecore *rev*' -Recurse -Force;
 
-ADD Sitecore /Sitecore
-ADD license.xml /Sitecore/Data
+COPY Sitecore /Sitecore
+COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
     Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `

--- a/sitecore/8.2 rev. 170407/Dockerfile
+++ b/sitecore/8.2 rev. 170407/Dockerfile
@@ -3,6 +3,8 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+ENV SITEPATH=C:\Sitecore\Website
+
 COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
@@ -17,7 +19,7 @@ COPY Sitecore /Sitecore
 COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
-    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `
+    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value $env:SITEPATH; `
     Set-ItemProperty -Path 'IIS:\AppPools\DefaultAppPool' -Name 'enable32BitAppOnWin64' -Value 'True'; `
     Set-Itemproperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `

--- a/sitecore/8.2 rev. 170614/Dockerfile
+++ b/sitecore/8.2 rev. 170614/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ADD *.zip .
+COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item 'C:\Sitecore*.zip' -Force; `
@@ -13,8 +13,8 @@ RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item -Path 'C:\Sitecore\Data\logs' -Recurse -Force; `
     Remove-Item -Path 'C:\Sitecore *rev*' -Recurse -Force;
 
-ADD Sitecore /Sitecore
-ADD license.xml /Sitecore/Data
+COPY Sitecore /Sitecore
+COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
     Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `

--- a/sitecore/8.2 rev. 170614/Dockerfile
+++ b/sitecore/8.2 rev. 170614/Dockerfile
@@ -3,6 +3,8 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+ENV SITEPATH=C:\Sitecore\Website
+
 COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
@@ -17,7 +19,7 @@ COPY Sitecore /Sitecore
 COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
-    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `
+    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value $env:SITEPATH; `
     Set-ItemProperty -Path 'IIS:\AppPools\DefaultAppPool' -Name 'enable32BitAppOnWin64' -Value 'True'; `
     Set-Itemproperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `

--- a/sitecore/8.2 rev. 170728/Dockerfile
+++ b/sitecore/8.2 rev. 170728/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ADD *.zip .
+COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item 'C:\Sitecore*.zip' -Force; `
@@ -13,8 +13,8 @@ RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item -Path 'C:\Sitecore\Data\logs' -Recurse -Force; `
     Remove-Item -Path 'C:\Sitecore *rev*' -Recurse -Force;
 
-ADD Sitecore /Sitecore
-ADD license.xml /Sitecore/Data
+COPY Sitecore /Sitecore
+COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
     Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `

--- a/sitecore/8.2 rev. 170728/Dockerfile
+++ b/sitecore/8.2 rev. 170728/Dockerfile
@@ -3,6 +3,8 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+ENV SITEPATH=C:\Sitecore\Website
+
 COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
@@ -17,7 +19,7 @@ COPY Sitecore /Sitecore
 COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
-    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `
+    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value $env:SITEPATH; `
     Set-ItemProperty -Path 'IIS:\AppPools\DefaultAppPool' -Name 'enable32BitAppOnWin64' -Value 'True'; `
     Set-Itemproperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `

--- a/sitecore/8.2 rev. 171121/Dockerfile
+++ b/sitecore/8.2 rev. 171121/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ADD *.zip .
+COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item 'C:\Sitecore*.zip' -Force; `
@@ -13,8 +13,8 @@ RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
     Remove-Item -Path 'C:\Sitecore\Data\logs' -Recurse -Force; `
     Remove-Item -Path 'C:\Sitecore *rev*' -Recurse -Force;
 
-ADD Sitecore /Sitecore
-ADD license.xml /Sitecore/Data
+COPY Sitecore /Sitecore
+COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
     Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `

--- a/sitecore/8.2 rev. 171121/Dockerfile
+++ b/sitecore/8.2 rev. 171121/Dockerfile
@@ -3,6 +3,8 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+ENV SITEPATH=C:\Sitecore\Website
+
 COPY *.zip .
 
 RUN Expand-Archive -Path 'C:\Sitecore*.zip' -DestinationPath 'C:'; `
@@ -17,7 +19,7 @@ COPY Sitecore /Sitecore
 COPY license.xml /Sitecore/Data
 
 RUN Import-Module WebAdministration; `
-    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value 'C:\Sitecore\Website'; `
+    Set-ItemProperty -Path 'IIS:\Sites\Default Web Site' -Name 'physicalPath' -Value $env:SITEPATH; `
     Set-ItemProperty -Path 'IIS:\AppPools\DefaultAppPool' -Name 'enable32BitAppOnWin64' -Value 'True'; `
     Set-Itemproperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `

--- a/sitecore/9.0.0 rev. 171002 SQL/Dockerfile
+++ b/sitecore/9.0.0 rev. 171002 SQL/Dockerfile
@@ -11,13 +11,13 @@ ENV DATA_PATH='c:/data/'
 
 VOLUME ${DATA_PATH}
 
-ADD *.zip ${INSTALL_PATH}
-ADD *-Databases.ps1 ${INSTALL_PATH}
+COPY *.zip ${INSTALL_PATH}
+COPY *-Databases.ps1 ${INSTALL_PATH}
 
 RUN & (Join-Path $env:INSTALL_PATH "Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
     & (Join-Path $env:INSTALL_PATH "Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; `
     Get-ChildItem -Path $env:INSTALL_PATH -Exclude "*.mdf", "*.ldf" | Remove-Item -Force;
 
-ADD Boot.ps1 .
+COPY Boot.ps1 .
 
 CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH

--- a/sitecore/9.0.0 rev. 171002 XM1 CD/Dockerfile
+++ b/sitecore/9.0.0 rev. 171002 XM1 CD/Dockerfile
@@ -11,7 +11,7 @@ ARG SIF_PACKAGE=${INSTALL_TEMP}\\'Sitecore*_cd.scwdp.zip'
 ARG WEBDEPLOY_MSI=${INSTALL_TEMP}\\webdeploy.msi
 ARG URLREWRITE_MSI=${INSTALL_TEMP}\\urlrewrite.msi
 
-ADD . ${INSTALL_TEMP}
+COPY . ${INSTALL_TEMP}
 ADD http://download.microsoft.com/download/0/1/D/01DC28EA-638C-4A22-A57B-4CEF97755C6C/WebDeploy_amd64_en-US.msi ${WEBDEPLOY_MSI}
 ADD http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi ${URLREWRITE_MSI}
 

--- a/sitecore/9.0.0 rev. 171002 XM1 CD/Dockerfile
+++ b/sitecore/9.0.0 rev. 171002 XM1 CD/Dockerfile
@@ -4,6 +4,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV SITENAME='sc'
+ENV SITEPATH=C:\inetpub\${SITENAME}
 ARG SQLADMIN_PASSWORD='HASH-epsom-sunset-cost7!'
 ARG INSTALL_TEMP='c:\\install'
 ARG SIF_CONFIG=${INSTALL_TEMP}\\sitecore-XM1-cd.json
@@ -26,7 +27,7 @@ RUN Start-Process msiexec.exe -ArgumentList '/i', $env:WEBDEPLOY_MSI, '/quiet', 
 RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath $env:INSTALL_TEMP; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `
     $config = Get-Content $env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
-    $config.Variables.'Site.PhysicalPath' = 'C:\inetpub\{0}' -f $env:SITENAME; `
+    $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
@@ -44,7 +45,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     -SolrCorePrefix $env:SITENAME `
     -Skip "CreateHostHeader", "CreateBindings", "StartAppPool", "StartWebsite"; `
     Remove-Item -Path 'C:\\*.log'; `
-    Remove-Item -Path ('C:\\inetpub\\{0}\\App_Data\\logs' -f $env:SITENAME) -Force -Recurse; `
+    Remove-Item -Path ('{0}\\App_Data\\logs' -f $env:SITEPATH) -Force -Recurse; `
     Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\Sitecore') -Destination 'C:/' -Recurse -Force; `
     Set-WebConfiguration -PSPath ('IIS:\Sites\{0}' -f $env:SITENAME) -Filter '/system.web/customErrors/@mode' -Value 'Off'
 

--- a/sitecore/9.0.0 rev. 171002 XM1 CM/Dockerfile
+++ b/sitecore/9.0.0 rev. 171002 XM1 CM/Dockerfile
@@ -4,6 +4,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV SITENAME='sc'
+ENV SITEPATH=C:\inetpub\${SITENAME}
 ARG SQLADMIN_PASSWORD='HASH-epsom-sunset-cost7!'
 ARG INSTALL_TEMP='c:\\install'
 ARG SIF_CONFIG=${INSTALL_TEMP}\\sitecore-XM1-cm.json
@@ -27,7 +28,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `
     $config = Get-Content $env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
     $config.Tasks.InstallWDP.Params.Arguments | Add-Member -Name 'Skip' -Value @(@{'ObjectName' = 'dbDacFx'}, @{'ObjectName' = 'dbFullSql'}) -MemberType NoteProperty; `
-    $config.Variables.'Site.PhysicalPath' = 'C:\inetpub\{0}' -f $env:SITENAME; `
+    $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
@@ -48,7 +49,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     -SolrCorePrefix $env:SITENAME `
     -Skip "RemoveDefaultBinding", "CreateBindingsWithThumprint", "CreateHostHeader", "CreateBindingsWithDevelopmentThumprint", "StartAppPool", "StartWebsite"; `
     Remove-Item -Path 'C:\\*.log'; `
-    Remove-Item -Path ('C:\\inetpub\\{0}\\App_Data\\logs' -f $env:SITENAME) -Force -Recurse; `
+    Remove-Item -Path ('{0}\\App_Data\\logs' -f $env:SITEPATH) -Force -Recurse; `
     Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\Sitecore') -Destination 'C:/' -Recurse -Force; `
     $iisPath = ('IIS:\Sites\{0}' -f $env:SITENAME); `
     Clear-WebConfiguration -PSPath $iisPath -Filter '/system.webserver/rewrite/rules/rule'; `

--- a/sitecore/9.0.0 rev. 171002 XM1 CM/Dockerfile
+++ b/sitecore/9.0.0 rev. 171002 XM1 CM/Dockerfile
@@ -11,7 +11,7 @@ ARG SIF_PACKAGE=${INSTALL_TEMP}\\'Sitecore*_cm.scwdp.zip'
 ARG WEBDEPLOY_MSI=${INSTALL_TEMP}\\webdeploy.msi
 ARG URLREWRITE_MSI=${INSTALL_TEMP}\\urlrewrite.msi
 
-ADD . ${INSTALL_TEMP}
+COPY . ${INSTALL_TEMP}
 ADD http://download.microsoft.com/download/0/1/D/01DC28EA-638C-4A22-A57B-4CEF97755C6C/WebDeploy_amd64_en-US.msi ${WEBDEPLOY_MSI}
 ADD http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi ${URLREWRITE_MSI}
 

--- a/sitecore/9.0.1 rev. 171219 SQL/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 SQL/Dockerfile
@@ -11,13 +11,13 @@ ENV DATA_PATH='c:/data/'
 
 VOLUME ${DATA_PATH}
 
-ADD *.zip ${INSTALL_PATH}
-ADD *-Databases.ps1 ${INSTALL_PATH}
+COPY *.zip ${INSTALL_PATH}
+COPY *-Databases.ps1 ${INSTALL_PATH}
 
 RUN & (Join-Path $env:INSTALL_PATH "Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
     & (Join-Path $env:INSTALL_PATH "Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; `
     Get-ChildItem -Path $env:INSTALL_PATH -Exclude "*.mdf", "*.ldf" | Remove-Item -Force;
 
-ADD Boot.ps1 .
+COPY Boot.ps1 .
 
 CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH

--- a/sitecore/9.0.1 rev. 171219 Solr/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 Solr/Dockerfile
@@ -32,7 +32,7 @@ RUN Install-PackageProvider -Name NuGet -Force | Out-Null; `
 ARG INSTALL_TEMP='c:\\install'
 ARG SIF_CONFIG=${INSTALL_TEMP}\\sitecore-solr.json
 ENV SOLR_PREFIX='sc'
-ADD . ${INSTALL_TEMP}
+COPY . ${INSTALL_TEMP}
 RUN & 'c:/solr/bin/solr.cmd' start -p 8983; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath $env:INSTALL_TEMP; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `
@@ -67,6 +67,6 @@ ENV SOLR_HOME=g:/
 EXPOSE 8983
 
 # Boot
-ADD Boot.ps1 .
+COPY Boot.ps1 .
 
 CMD C:/Boot.ps1 -SolrPath 'c:/solr' -SolrPort 8983 -InstallPath 'c:/clean' -DataPath 'c:/data'

--- a/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
@@ -4,6 +4,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV SITENAME='sc'
+ENV SITEPATH=C:\inetpub\${SITENAME}
 ARG SQLADMIN_PASSWORD='HASH-epsom-sunset-cost7!'
 ARG INSTALL_TEMP='c:\\install'
 ARG SIF_CONFIG=${INSTALL_TEMP}\\sitecore-XM1-cd.json
@@ -29,7 +30,7 @@ RUN Start-Process msiexec.exe -ArgumentList '/i', $env:WEBDEPLOY_MSI, '/quiet', 
 RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath $env:INSTALL_TEMP; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `
     $config = Get-Content $env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
-    $config.Variables.'Site.PhysicalPath' = 'C:\inetpub\{0}' -f $env:SITENAME; `
+    $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
@@ -48,7 +49,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     -SolrCorePrefix $env:SITENAME `
     -Skip "CreateHostHeader", "CreateBindings", "StartAppPool", "StartWebsite"; `
     Remove-Item -Path 'C:\\*.log'; `
-    Remove-Item -Path ('C:\\inetpub\\{0}\\App_Data\\logs' -f $env:SITENAME) -Force -Recurse; `
+    Remove-Item -Path ('{0}\\App_Data\\logs' -f $env:SITEPATH) -Force -Recurse; `
     Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\Sitecore') -Destination 'C:/' -Recurse -Force; `
     Set-WebConfiguration -PSPath ('IIS:\Sites\{0}' -f $env:SITENAME) -Filter '/system.web/customErrors/@mode' -Value 'Off'
 

--- a/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
@@ -13,7 +13,7 @@ ARG WEBDEPLOY_MSI=${INSTALL_TEMP}\\webdeploy.msi
 ARG URLREWRITE_MSI=${INSTALL_TEMP}\\urlrewrite.msi
 ARG VCREDISTX64_EXE=${INSTALL_TEMP}\\VC_redist.x64.exe
 
-ADD . ${INSTALL_TEMP}
+COPY . ${INSTALL_TEMP}
 ADD http://download.microsoft.com/download/0/1/D/01DC28EA-638C-4A22-A57B-4CEF97755C6C/WebDeploy_amd64_en-US.msi ${WEBDEPLOY_MSI}
 ADD http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi ${URLREWRITE_MSI}
 ADD https://aka.ms/vs/15/release/VC_redist.x64.exe ${VCREDISTX64_EXE}

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -4,6 +4,7 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV SITENAME='sc'
+ENV SITEPATH=C:\inetpub\${SITENAME}
 ARG SQLADMIN_PASSWORD='HASH-epsom-sunset-cost7!'
 ARG INSTALL_TEMP='c:\\install'
 ARG SIF_CONFIG=${INSTALL_TEMP}\\sitecore-XM1-cm.json
@@ -30,7 +31,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `
     $config = Get-Content $env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
     $config.Tasks.InstallWDP.Params.Arguments | Add-Member -Name 'Skip' -Value @(@{'ObjectName' = 'dbDacFx'}, @{'ObjectName' = 'dbFullSql'}) -MemberType NoteProperty; `
-    $config.Variables.'Site.PhysicalPath' = 'C:\inetpub\{0}' -f $env:SITENAME; `
+    $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
@@ -52,7 +53,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     -SolrCorePrefix $env:SITENAME `
     -Skip "RemoveDefaultBinding", "CreateBindingsWithThumprint", "CreateHostHeader", "CreateBindingsWithDevelopmentThumprint", "StartAppPool", "StartWebsite", "UpdateSolrSchema"; `
     Remove-Item -Path 'C:\\*.log'; `
-    Remove-Item -Path ('C:\\inetpub\\{0}\\App_Data\\logs' -f $env:SITENAME) -Force -Recurse; `
+    Remove-Item -Path ('{0}\\App_Data\\logs' -f $env:SITEPATH) -Force -Recurse; `
     Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\Sitecore') -Destination 'C:/' -Recurse -Force; `
     $iisPath = ('IIS:\Sites\{0}' -f $env:SITENAME); `
     Clear-WebConfiguration -PSPath $iisPath -Filter '/system.webserver/rewrite/rules/rule'; `

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -13,7 +13,7 @@ ARG WEBDEPLOY_MSI=${INSTALL_TEMP}\\webdeploy.msi
 ARG URLREWRITE_MSI=${INSTALL_TEMP}\\urlrewrite.msi
 ARG VCREDISTX64_EXE=${INSTALL_TEMP}\\VC_redist.x64.exe
 
-ADD . ${INSTALL_TEMP}
+COPY . ${INSTALL_TEMP}
 ADD http://download.microsoft.com/download/0/1/D/01DC28EA-638C-4A22-A57B-4CEF97755C6C/WebDeploy_amd64_en-US.msi ${WEBDEPLOY_MSI}
 ADD http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi ${URLREWRITE_MSI}
 ADD https://aka.ms/vs/15/release/VC_redist.x64.exe ${VCREDISTX64_EXE}


### PR DESCRIPTION
Changes done to Dockerfiles for SC 9.0.1 rev. 171219
- Create SITEPATH variable to centralize definition of Website folder
- Replace ADD with COPY to follow best practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy