### PR TITLE
Data folder (and license.xml) as volume among other

### DIFF
--- a/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
@@ -69,7 +69,6 @@ RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', 
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `
     Start-WebAppPool -Name $env:SITENAME; `
     Start-Website -Name $env:SITENAME; `
-    Remove-WebAppPool -Name 'DefaultAppPool'; `
     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
     Remove-Item -Path $env:DATAPATH -Force -Recurse; 
 

--- a/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
@@ -4,7 +4,8 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV SITENAME='sc'
-ENV SITEPATH=C:\inetpub\${SITENAME}
+ENV SITEPATH=C:\inetpub\${SITENAME}\Website
+ENV DATAPATH=C:\inetpub\${SITENAME}\Data
 ARG SQLADMIN_PASSWORD='HASH-epsom-sunset-cost7!'
 ARG INSTALL_TEMP='c:\\install'
 ARG SIF_CONFIG=${INSTALL_TEMP}\\sitecore-XM1-cd.json
@@ -30,10 +31,11 @@ RUN Start-Process msiexec.exe -ArgumentList '/i', $env:WEBDEPLOY_MSI, '/quiet', 
 RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath $env:INSTALL_TEMP; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `
     $config = Get-Content $env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
+    $config.Tasks.CreatePaths.Params.Exists += '[variable(''Site.DataFolder'')]'; `
     $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
+    $config.Variables.'Site.DataFolder' = $env:DATAPATH; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
-    Remove-WebAppPool -Name 'DefaultAppPool'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
     -Package $env:SIF_PACKAGE `
     -LicenseFile (Join-Path $env:INSTALL_TEMP '\\license.xml') `
@@ -50,15 +52,25 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     -SolrCorePrefix $env:SITENAME `
     -Skip "CreateHostHeader", "CreateBindings", "StartAppPool", "StartWebsite"; `
     Remove-Item -Path 'C:\\*.log'; `
-    Remove-Item -Path ('{0}\\App_Data\\logs' -f $env:SITEPATH) -Force -Recurse; `
     Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\Sitecore') -Destination 'C:/' -Recurse -Force; `
-    Set-WebConfiguration -PSPath ('IIS:\Sites\{0}' -f $env:SITENAME) -Filter '/system.web/customErrors/@mode' -Value 'Off'
+    Set-WebConfiguration -PSPath ('IIS:\Sites\{0}' -f $env:SITENAME) -Filter '/system.web/customErrors/@mode' -Value 'Off'; `
+    $xml = New-Object XML; `
+    $xml.Load(('{0}\app_config\include\examples\DataFolder.config.example' -f $env:SITEPATH)); `
+    $nsm = New-Object Xml.XmlNamespaceManager($xml.NameTable); `
+    $nsm.AddNamespace('patch', 'http://www.sitecore.net/xmlconfig/'); `
+    $element = $xml.SelectSingleNode('//sc.variable[@name=''dataFolder'']/patch:attribute[@name=''value'']', $nsm); `
+    $element.InnerText=$env:DATAPATH; `
+    $xml.Save(('{0}\app_config\include\DataFolder.config' -f $env:SITEPATH));
 
 # Cleanup, post installation tweaks and start site
 RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', '/norestart' -NoNewWindow -Wait; `
     Uninstall-Module SitecoreInstallFramework -Force; `
-    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
     Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `
     Start-WebAppPool -Name $env:SITENAME; `
-    Start-Website -Name $env:SITENAME
+    Start-Website -Name $env:SITENAME; `
+    Remove-WebAppPool -Name 'DefaultAppPool'; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
+    Remove-Item -Path $env:DATAPATH -Force -Recurse; 
+
+VOLUME ${DATAPATH}

--- a/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CD/Dockerfile
@@ -33,6 +33,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
+    Remove-WebAppPool -Name 'DefaultAppPool'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
     -Package $env:SIF_PACKAGE `
     -LicenseFile (Join-Path $env:INSTALL_TEMP '\\license.xml') `

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -25,26 +25,18 @@ RUN Start-Process msiexec.exe -ArgumentList '/i', $env:WEBDEPLOY_MSI, '/quiet', 
     Start-Process $env:VCREDISTX64_EXE -ArgumentList '/install', '/passive', '/norestart' -NoNewWindow -Wait; `
     Install-PackageProvider -Name NuGet -Force | Out-Null; `
     Register-PSRepository -Name SitecoreGallery -SourceLocation https://sitecore.myget.org/F/sc-powershell/api/v2; `
-    Install-Module SitecoreInstallFramework -RequiredVersion 1.1.0 -Force; `
-	Import-Module WebAdministration;
+    Install-Module SitecoreInstallFramework -RequiredVersion 1.1.0 -Force; 
 
 # Install Sitecore
 RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath $env:INSTALL_TEMP; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `
     $config = Get-Content $env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
+    $config.Tasks.CreatePaths.Params.Exists += '[variable(''Site.DataFolder'')]'; `
     $config.Tasks.InstallWDP.Params.Arguments | Add-Member -Name 'Skip' -Value @(@{'ObjectName' = 'dbDacFx'}, @{'ObjectName' = 'dbFullSql'}) -MemberType NoteProperty; `
     $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
     $config.Variables.'Site.DataFolder' = $env:DATAPATH; `
-    $tasks = New-Object PSObject; `
-    $newTask = New-Object PSObject; `
-    $newTask | Add-Member -MemberType NoteProperty -Name 'Type' -Value 'EnsurePath'; `
-    $newTask | Add-Member -MemberType NoteProperty -Name 'Params' -Value @{'Exists'=@('[variable(''Site.DataFolder'')]')}; `
-    $tasks | Add-Member -MemberType NoteProperty -Name 'EnsureDataFolder' -Value $newTask; `
-    $config.Tasks.psobject.properties | % {$tasks | Add-Member -MemberType $_.MemberType -Name $_.Name -Value $_.Value}; `
-    $config.Tasks = $tasks; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
-    Remove-WebAppPool -Name 'DefaultAppPool'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
     -Package $env:SIF_PACKAGE `
     -LicenseFile (Join-Path $env:INSTALL_TEMP '\\license.xml') `
@@ -70,7 +62,15 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     Add-WebConfigurationProperty -PSPath $iisPath -Filter '/system.webServer/rewrite/outboundRules' -Name '.' -Value @{name = 'MakeLocationHeaderRelative' ; preCondition = 'IsSitecoreAbsoluteRedirect'; match = @{serverVariable = 'RESPONSE_LOCATION'; pattern = '(https?://[^:/]+):?([0-9]+)?(.*)'}; action = @{type = 'Rewrite'; value = '{R:3}'}}; `
     Add-WebConfigurationProperty -PSPath $iisPath -Filter '/system.webServer/rewrite/outboundRules/preConditions' -Name '.' -Value @{name = 'IsSitecoreAbsoluteRedirect'}; `
     Add-WebConfigurationProperty -PSPath $iisPath -Filter 'system.webServer/rewrite/outboundRules/preConditions/preCondition[@name=''IsSitecoreAbsoluteRedirect'']' -Name '.' -Value @{input = '{RESPONSE_LOCATION}'; pattern = '(https?://[^:/]+):?([0-9]+)?/sitecore/(.*)'}; `
-    Add-WebConfigurationProperty -PSPath $iisPath -Filter 'system.webServer/rewrite/outboundRules/preConditions/preCondition[@name=''IsSitecoreAbsoluteRedirect'']' -Name '.' -Value @{input = '{RESPONSE_STATUS}'; pattern = '3[0-9][0-9]'}
+    Add-WebConfigurationProperty -PSPath $iisPath -Filter 'system.webServer/rewrite/outboundRules/preConditions/preCondition[@name=''IsSitecoreAbsoluteRedirect'']' -Name '.' -Value @{input = '{RESPONSE_STATUS}'; pattern = '3[0-9][0-9]'}; `
+    $xml = New-Object XML; `
+    $xml.Load('C:\inetpub\sc\website\app_config\include\examples\DataFolder.config.example'); `
+    $nsm = New-Object Xml.XmlNamespaceManager($xml.NameTable); `
+    $nsm.AddNamespace('patch', 'http://www.sitecore.net/xmlconfig/'); `
+    $element = $xml.SelectSingleNode('//sc.variable[@name=''dataFolder'']/patch:attribute[@name=''value'']', $nsm); `
+    $element.InnerText= 'C:\inetpub\sc\Data'; `
+    $xml.Save('C:\inetpub\sc\website\app_config\include\DataFolder.config');
+
 
 # Cleanup, post installation tweaks and start site
 RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', '/norestart' -NoNewWindow -Wait; `
@@ -79,5 +79,6 @@ RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', 
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `    
     Start-WebAppPool -Name $env:SITENAME; `
     Start-Website -Name $env:SITENAME; `
+    Remove-WebAppPool -Name 'DefaultAppPool'; `
     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
     Remove-Item -Path 'C:\\*.log';

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -64,12 +64,12 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     Add-WebConfigurationProperty -PSPath $iisPath -Filter 'system.webServer/rewrite/outboundRules/preConditions/preCondition[@name=''IsSitecoreAbsoluteRedirect'']' -Name '.' -Value @{input = '{RESPONSE_LOCATION}'; pattern = '(https?://[^:/]+):?([0-9]+)?/sitecore/(.*)'}; `
     Add-WebConfigurationProperty -PSPath $iisPath -Filter 'system.webServer/rewrite/outboundRules/preConditions/preCondition[@name=''IsSitecoreAbsoluteRedirect'']' -Name '.' -Value @{input = '{RESPONSE_STATUS}'; pattern = '3[0-9][0-9]'}; `
     $xml = New-Object XML; `
-    $xml.Load('C:\inetpub\sc\website\app_config\include\examples\DataFolder.config.example'); `
+    $xml.Load(('{0}\app_config\include\examples\DataFolder.config.example' -f $env:SITEPATH)); `
     $nsm = New-Object Xml.XmlNamespaceManager($xml.NameTable); `
     $nsm.AddNamespace('patch', 'http://www.sitecore.net/xmlconfig/'); `
     $element = $xml.SelectSingleNode('//sc.variable[@name=''dataFolder'']/patch:attribute[@name=''value'']', $nsm); `
-    $element.InnerText= 'C:\inetpub\sc\Data'; `
-    $xml.Save('C:\inetpub\sc\website\app_config\include\DataFolder.config');
+    $element.InnerText=$env:DATAPATH; `
+    $xml.Save(('{0}\app_config\include\DataFolder.config' -f $env:SITEPATH));
 
 
 # Cleanup, post installation tweaks and start site

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -34,6 +34,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
+    Remove-WebAppPool -Name 'DefaultAppPool'; `
     Install-SitecoreConfiguration -Path $env:SIF_CONFIG `
     -Package $env:SIF_PACKAGE `
     -LicenseFile (Join-Path $env:INSTALL_TEMP '\\license.xml') `

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -55,6 +55,7 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     -SolrUrl "http://solr:8983/solr" `
     -SolrCorePrefix $env:SITENAME `
     -Skip "RemoveDefaultBinding", "CreateBindingsWithThumprint", "CreateHostHeader", "CreateBindingsWithDevelopmentThumprint", "StartAppPool", "StartWebsite", "UpdateSolrSchema"; `
+    Remove-Item -Path 'C:\\*.log'; `
     Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\Sitecore') -Destination 'C:/' -Recurse -Force; `
     $iisPath = ('IIS:\Sites\{0}' -f $env:SITENAME); `
     Clear-WebConfiguration -PSPath $iisPath -Filter '/system.webserver/rewrite/rules/rule'; `
@@ -81,7 +82,6 @@ RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', 
     Start-Website -Name $env:SITENAME; `
     Remove-WebAppPool -Name 'DefaultAppPool'; `
     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
-    Remove-Item -Path 'C:\\*.log'; `
 	Remove-Item -Path $env:DATAPATH -Force -Recurse; 
 
 VOLUME ${DATAPATH}

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -80,7 +80,6 @@ RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', 
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `    
     Start-WebAppPool -Name $env:SITENAME; `
     Start-Website -Name $env:SITENAME; `
-    Remove-WebAppPool -Name 'DefaultAppPool'; `
     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
     Remove-Item -Path $env:DATAPATH -Force -Recurse; 
 

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -81,4 +81,7 @@ RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', 
     Start-Website -Name $env:SITENAME; `
     Remove-WebAppPool -Name 'DefaultAppPool'; `
     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
-    Remove-Item -Path 'C:\\*.log';
+    Remove-Item -Path 'C:\\*.log'; `
+	Remove-Item -Path $env:DATAPATH -Force -Recurse; 
+
+VOLUME ${DATAPATH}

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -82,6 +82,6 @@ RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', 
     Start-Website -Name $env:SITENAME; `
     Remove-WebAppPool -Name 'DefaultAppPool'; `
     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
-	Remove-Item -Path $env:DATAPATH -Force -Recurse; 
+    Remove-Item -Path $env:DATAPATH -Force -Recurse; 
 
 VOLUME ${DATAPATH}

--- a/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
+++ b/sitecore/9.0.1 rev. 171219 XM1 CM/Dockerfile
@@ -4,7 +4,8 @@ FROM microsoft/aspnet:4.7.1-windowsservercore-1709
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV SITENAME='sc'
-ENV SITEPATH=C:\inetpub\${SITENAME}
+ENV SITEPATH=C:\inetpub\${SITENAME}\Website
+ENV DATAPATH=C:\inetpub\${SITENAME}\Data
 ARG SQLADMIN_PASSWORD='HASH-epsom-sunset-cost7!'
 ARG INSTALL_TEMP='c:\\install'
 ARG SIF_CONFIG=${INSTALL_TEMP}\\sitecore-XM1-cm.json
@@ -24,7 +25,8 @@ RUN Start-Process msiexec.exe -ArgumentList '/i', $env:WEBDEPLOY_MSI, '/quiet', 
     Start-Process $env:VCREDISTX64_EXE -ArgumentList '/install', '/passive', '/norestart' -NoNewWindow -Wait; `
     Install-PackageProvider -Name NuGet -Force | Out-Null; `
     Register-PSRepository -Name SitecoreGallery -SourceLocation https://sitecore.myget.org/F/sc-powershell/api/v2; `
-    Install-Module SitecoreInstallFramework -RequiredVersion 1.1.0 -Force;
+    Install-Module SitecoreInstallFramework -RequiredVersion 1.1.0 -Force; `
+	Import-Module WebAdministration;
 
 # Install Sitecore
 RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath $env:INSTALL_TEMP; `
@@ -32,6 +34,14 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     $config = Get-Content $env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
     $config.Tasks.InstallWDP.Params.Arguments | Add-Member -Name 'Skip' -Value @(@{'ObjectName' = 'dbDacFx'}, @{'ObjectName' = 'dbFullSql'}) -MemberType NoteProperty; `
     $config.Variables.'Site.PhysicalPath' = $env:SITEPATH; `
+    $config.Variables.'Site.DataFolder' = $env:DATAPATH; `
+    $tasks = New-Object PSObject; `
+    $newTask = New-Object PSObject; `
+    $newTask | Add-Member -MemberType NoteProperty -Name 'Type' -Value 'EnsurePath'; `
+    $newTask | Add-Member -MemberType NoteProperty -Name 'Params' -Value @{'Exists'=@('[variable(''Site.DataFolder'')]')}; `
+    $tasks | Add-Member -MemberType NoteProperty -Name 'EnsureDataFolder' -Value $newTask; `
+    $config.Tasks.psobject.properties | % {$tasks | Add-Member -MemberType $_.MemberType -Name $_.Name -Value $_.Value}; `
+    $config.Tasks = $tasks; `
     ConvertTo-Json $config -Depth 50 | Set-Content -Path $env:SIF_CONFIG; `
     Remove-Website -Name 'Default Web Site'; `
     Remove-WebAppPool -Name 'DefaultAppPool'; `
@@ -53,8 +63,6 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
     -SolrUrl "http://solr:8983/solr" `
     -SolrCorePrefix $env:SITENAME `
     -Skip "RemoveDefaultBinding", "CreateBindingsWithThumprint", "CreateHostHeader", "CreateBindingsWithDevelopmentThumprint", "StartAppPool", "StartWebsite", "UpdateSolrSchema"; `
-    Remove-Item -Path 'C:\\*.log'; `
-    Remove-Item -Path ('{0}\\App_Data\\logs' -f $env:SITEPATH) -Force -Recurse; `
     Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\Sitecore') -Destination 'C:/' -Recurse -Force; `
     $iisPath = ('IIS:\Sites\{0}' -f $env:SITENAME); `
     Clear-WebConfiguration -PSPath $iisPath -Filter '/system.webserver/rewrite/rules/rule'; `
@@ -67,8 +75,9 @@ RUN Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*.zip') -DestinationPath 
 # Cleanup, post installation tweaks and start site
 RUN Start-Process msiexec.exe -ArgumentList '/x', $env:WEBDEPLOY_MSI, '/quiet', '/norestart' -NoNewWindow -Wait; `
     Uninstall-Module SitecoreInstallFramework -Force; `
-    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
     Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord; `
     setx /M PATH $($env:PATH + ';C:\Sitecore\Scripts'); `    
     Start-WebAppPool -Name $env:SITENAME; `
-    Start-Website -Name $env:SITENAME
+    Start-Website -Name $env:SITENAME; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; `
+    Remove-Item -Path 'C:\\*.log';


### PR DESCRIPTION
**Included Changes:**

- Data folder out of Website folder
- Data folder defined as a volume for persistence and to support license.xml file out of the image
- Data folder is emptied to support becoming a volume
- license.xml file is deleted from the image (along with other content in Data folder)
- Support to make Website folder also a volume (only at debugging time)
- Demo with VS2017 available soon with support for:
   - Local Website at debugging time (no need for synchronization)
   - Website folder embedded in the image at runtime.
   - Website folder files automatically copied from image to Development environment (if missing) (same as databases).
   - Attach to IIS process from VS2017

**Caveats:**

- Website folder has been moved to a different location
- Only implemented over "Sitecore 9.0.1 rev. 171219" for discussion. Changes to be reproduced in V9.0 if accepted.
- Not documented yet