### PR TITLE
Support pushing to remote repository without local changes

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -11,9 +11,8 @@ param(
     [ValidateNotNullOrEmpty()] 
     [string]$Repository,
     [Parameter(Mandatory = $false)]
-    [switch]$SkipPush,
-    [Parameter(Mandatory = $false)]
-    [switch]$ForcePush,
+    [ValidateSet('Always', 'IfChanged', 'Never')]
+    [string]$PushMode = 'Never',
     [Parameter(Mandatory = $false)]
     [switch]$RemoveInstallationSourceFiles
 )
@@ -143,23 +142,21 @@ Find-SitecoreVersions -Path $imagesPath -InstallSourcePath $InstallSourcePath -F
 
     $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw ("Build of '{0}' failed" -f $tag) }
 
-    # Determine if we need to push
-    $currentDigest = (docker image inspect $tag) | ConvertFrom-Json | ForEach-Object { $_.Id }
-    
     if ($RemoveInstallationSourceFiles) {
         Write-Host ("Done with Installation Source - Removing  '{0}'" -f $targetPath) -ForegroundColor Green
         Remove-Item $targetPath -Force
     }
 
-    if ((-Not $ForcePush) -And ($currentDigest -eq $previousDigest)) {
-        Write-Host "Done, current digest is the same as the previous, image has not changed since last build." -ForegroundColor Green
-
+    if ($PushMode -eq 'Never') {
+        Write-Warning "Done. PushMode is set to 'Never' therefore the image is not pushed to the remote repository."
         return
     }
     
-    if ($SkipPush) {
-        Write-Warning "Done, SkipPush switch used."
-
+    # Determine if we need to push
+    $currentDigest = (docker image inspect $tag) | ConvertFrom-Json | ForEach-Object { $_.Id }
+    
+    if (($PushMode -eq 'IfChanged') -And ($currentDigest -eq $previousDigest)) {
+        Write-Host "Done. PushMode is set to 'IfChanged' and the image has not changed since last build, therefore is not pushed to the remote repository." -ForegroundColor Green
         return
     }
     

--- a/Build.ps1
+++ b/Build.ps1
@@ -13,6 +13,8 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$SkipPush,
     [Parameter(Mandatory = $false)]
+    [switch]$ForcePush,
+    [Parameter(Mandatory = $false)]
     [switch]$RemoveInstallationSourceFiles
 )
 
@@ -149,7 +151,7 @@ Find-SitecoreVersions -Path $imagesPath -InstallSourcePath $InstallSourcePath -F
         Remove-Item $targetPath -Force
     }
 
-    if ($currentDigest -eq $previousDigest) {
+    if ((-Not $ForcePush) -And ($currentDigest -eq $previousDigest)) {
         Write-Host "Done, current digest is the same as the previous, image has not changed since last build." -ForegroundColor Green
 
         return


### PR DESCRIPTION
This is a tiny change to support pushing to the remote repository even if no changes are detected locally.

For performance reasons, it may be convenient building the images locally without pushing them every time to the remote repository. Once the images are validated and do not need additional changes then is time to push them to the remote repository.

With this change, the Build.ps1 file will support this scenario by providing the new parameter -ForcePush which will make the script push the images even if no changes are detected locally. Please notice that -SkipPush has more priority than -ForcePush, meaning that if -SkipPush is passed then -ForcePush will be ignored.