### PR TITLE
Updated install file to work with PowerShell 6

### DIFF
--- a/modules/Sitecore.DockerImages.Management/install.ps1
+++ b/modules/Sitecore.DockerImages.Management/install.ps1
@@ -1,6 +1,8 @@
 #
 # This script will install module in Powershell modules localization.
-# Install means copy files from repo to $env:ProgramFiles\WindowsPowerShell\Modules\$moduleName"
+# Install means copy files from repo to $env:ProgramFiles\*PowerShell\Modules\$moduleName
+# PowerShell 6 changes the default paths for identifying installed modules. The wildcard
+# in the pattern resolves the discrepancy.
 #
 $moduleName = "Sitecore.DockerImages.Management"
 $projectFolder = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -14,7 +16,8 @@ $modulePath = "$projectFolder"
 
 Foreach ($psPath in $env:PSModulePath.Split(";"))
 {
-	if ($psPath -like 'C:\Program Files\*PowerShell\Modules')
+	$pattern = "$env:ProgramFiles\*PowerShell\Modules";
+	if ($psPath -like $pattern)
 	{
 		$targetPath = Join-Path $psPath -ChildPath "$moduleName"
 

--- a/modules/Sitecore.DockerImages.Management/install.ps1
+++ b/modules/Sitecore.DockerImages.Management/install.ps1
@@ -5,36 +5,41 @@
 $moduleName = "Sitecore.DockerImages.Management"
 $projectFolder = Split-Path -Parent $MyInvocation.MyCommand.Path
 $solutionFolder = Split-Path -Parent $projectFolder
-#$modulePath = Join-Path $projectFolder -ChildPath $moduleName 
+#$modulePath = Join-Path $projectFolder -ChildPath $moduleName
 #$modulePath = "$moduleName"
 $modulePath = "$projectFolder"
 
 
 #region Install module"
 
-$targetPath = Join-Path $env:ProgramFiles -ChildPath "\WindowsPowerShell\Modules\$moduleName"
-
-if( -not (Test-Path -Path $targetPath))
+Foreach ($psPath in $env:PSModulePath.Split(";"))
 {
-	md $targetPath
+	if ($psPath -like 'C:\Program Files\*PowerShell\Modules')
+	{
+		$targetPath = Join-Path $psPath -ChildPath "$moduleName"
+
+		if( -not (Test-Path -Path $targetPath))
+		{
+			md $targetPath
+		}
+
+		Write-Output "SolutionFolder:" $solutionFolder
+		Write-Output "ProjectFolder:" $projectFolder
+		Write-Output "Source: $modulePath"
+		Write-Output "Path: $targetPath"
+
+		Remove-Item "$targetPath\*" -Verbose -Recurse -Force
+
+		md "$targetPath\Functions" -Force
+		md "$targetPath\Private" -Force
+		#md "$targetPath\PublicClasses" -Force
+		$filesToExclude = @( "install.ps1", "*.tests.ps1" )
+
+		Copy-Item -Path $modulePath\* -Destination "$targetPath" -Include *.psd1, *.psm1, *.ps1, *.md -Exclude $filesToExclude   -Force -Verbose -Recurse
+		Copy-Item -Recurse -Path $modulePath\Functions\* -Destination "$targetPath\Functions" -Include *.psd1, *.psm1, *.ps1 -Exclude $filesToExclude -Force -Verbose
+		Copy-Item -Recurse -Path $modulePath\Private\* -Destination "$targetPath\Private" -Include *.psd1, *.psm1, *.ps1 -Exclude $filesToExclude -Force -Verbose
+		#Copy-Item -Recurse -Path $modulePath\PublicClasses\* -Destination "$targetPath\PublicClasses" -Include *.psd1, *.psm1, *.ps1 -Exclude $filesToExclude -Force -Verbose
+		Break
+	}
 }
-
-Write-Output "SolutionFolder:" $solutionFolder
-Write-Output "ProjectFolder:" $projectFolder
-Write-Output "Source: $modulePath"
-Write-Output "Path: $targetPath"
-
-Remove-Item "$targetPath\*" -Verbose -Recurse -Force
-
-
-md "$targetPath\Functions" -Force 
-md "$targetPath\Private" -Force 
-#md "$targetPath\PublicClasses" -Force 
-$filesToExclude = @( "install.ps1", "*.tests.ps1" )
-
-Copy-Item -Path $modulePath\* -Destination "$targetPath" -Include *.psd1, *.psm1, *.ps1, *.md -Exclude $filesToExclude   -Force -Verbose -Recurse 
-Copy-Item -Recurse -Path $modulePath\Functions\* -Destination "$targetPath\Functions" -Include *.psd1, *.psm1, *.ps1 -Exclude $filesToExclude -Force -Verbose
-Copy-Item -Recurse -Path $modulePath\Private\* -Destination "$targetPath\Private" -Include *.psd1, *.psm1, *.ps1 -Exclude $filesToExclude -Force -Verbose
-#Copy-Item -Recurse -Path $modulePath\PublicClasses\* -Destination "$targetPath\PublicClasses" -Include *.psd1, *.psm1, *.ps1 -Exclude $filesToExclude -Force -Verbose
-
 #endregion


### PR DESCRIPTION
Changed install file to use PSModulePath to determine the correct module folder. This solves a problem installing for PowerShell 6.