### PR TITLE
typo, same tag name, rename from ltsc2019 to 1903

### DIFF
--- a/variants/9.1.1/windowsservercore/sxa/sitecore-xm1-sxa-1.8.1-sqldev/build.json
+++ b/variants/9.1.1/windowsservercore/sxa/sitecore-xm1-sxa-1.8.1-sqldev/build.json
@@ -7,9 +7,9 @@
             ]
         },
         {
-            "tag": "sitecore-xm1-sxa-1.8.1-sqldev:9.1.1-windowsservercore-ltsc2019",
+            "tag": "sitecore-xm1-sxa-1.8.1-sqldev:9.1.1-windowsservercore-1903",
             "build-options": [
-                "--build-arg BASE_IMAGE=sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019"
+                "--build-arg BASE_IMAGE=sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-1903"
             ]
         }
     ],


### PR DESCRIPTION
duplicate tag on sitecore-xp-pse-5.0-sqldev:9.1.1, fix the typo.