### PR TITLE
SQL Server on Linux fixes

### DIFF
--- a/linux/9.2.0 rev. 002893/sitecore-xm-sql/attach-databases.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xm-sql/attach-databases.sh
@@ -16,7 +16,7 @@ for filename in $dataDir/*.mdf; do
 
     echo "### Attaching '$databaseName' using '$mdfPath' and '$ldfPath'..."
 
-    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
+    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -l 300 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
 done
 
 echo "### Databases ready."

--- a/linux/9.2.0 rev. 002893/sitecore-xm-sql/attach-databases.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xm-sql/attach-databases.sh
@@ -16,7 +16,7 @@ for filename in $dataDir/*.mdf; do
 
     echo "### Attaching '$databaseName' using '$mdfPath' and '$ldfPath'..."
 
-    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 30 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
+    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
 done
 
 echo "### Databases ready."

--- a/linux/9.2.0 rev. 002893/sitecore-xm-sql/boot.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xm-sql/boot.sh
@@ -5,13 +5,13 @@ dataDir=$2
 
 # prepare data
 if ls $dataDir/*.mdf 1> /dev/null 2>&1; then
+    echo "### Done, existing data found in '$dataDir'..."
+else
     echo "### No data found in '$dataDir', seeding..."
    
     cp -R --verbose $cleanDir/. $dataDir/
 
     echo "### Done seeding."
-else
-    echo "### Done, existing data found in '$dataDir'..."
 fi
 
 asyncRun() {

--- a/linux/9.2.0 rev. 002893/sitecore-xm-sql/boot.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xm-sql/boot.sh
@@ -4,7 +4,7 @@ cleanDir=$1
 dataDir=$2
 
 # prepare data
-if [ -z "$(ls -A $dataDir)" ]; then
+if ls $dataDir/*.mdf 1> /dev/null 2>&1; then
     echo "### No data found in '$dataDir', seeding..."
    
     cp -R --verbose $cleanDir/. $dataDir/

--- a/linux/9.2.0 rev. 002893/sitecore-xp-sql/attach-databases.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xp-sql/attach-databases.sh
@@ -16,14 +16,14 @@ for filename in $dataDir/*.mdf; do
 
     echo "### Attaching '$databaseName' using '$mdfPath' and '$ldfPath'..."
 
-    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
+    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -l 300 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
 done
 
 echo "### Preparing shards..."
 
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "EXEC sp_MSforeachdb 'IF charindex(''${DB_PREFIX}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'"
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '${SQL_HOSTNAME}'"
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -l 300 -Q "EXEC sp_MSforeachdb 'IF charindex(''${DB_PREFIX}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -l 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '${SQL_HOSTNAME}'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -l 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -l 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
 
 echo "### Databases ready."

--- a/linux/9.2.0 rev. 002893/sitecore-xp-sql/attach-databases.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xp-sql/attach-databases.sh
@@ -16,14 +16,14 @@ for filename in $dataDir/*.mdf; do
 
     echo "### Attaching '$databaseName' using '$mdfPath' and '$ldfPath'..."
 
-    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
+    /opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "CREATE DATABASE [$databaseName] ON (FILENAME = '$mdfPath'),(FILENAME = '$ldfPath') FOR ATTACH"
 done
 
 echo "### Preparing shards..."
 
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -Q "EXEC sp_MSforeachdb 'IF charindex(''${DB_PREFIX}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'"
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '${SQL_HOSTNAME}'"
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
-/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 60 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "EXEC sp_MSforeachdb 'IF charindex(''${DB_PREFIX}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '${SQL_HOSTNAME}'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
+/opt/mssql-tools/bin/sqlcmd -S . -U SA -P $SA_PASSWORD -t 300 -Q "UPDATE [${DB_PREFIX}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '${SQL_HOSTNAME}'"
 
 echo "### Databases ready."

--- a/linux/9.2.0 rev. 002893/sitecore-xp-sql/boot.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xp-sql/boot.sh
@@ -5,13 +5,13 @@ dataDir=$2
 
 # prepare data
 if ls $dataDir/*.mdf 1> /dev/null 2>&1; then
+    echo "### Done, existing data found in '$dataDir'..."
+else
     echo "### No data found in '$dataDir', seeding..."
    
     cp -R --verbose $cleanDir/. $dataDir/
 
     echo "### Done seeding."
-else
-    echo "### Done, existing data found in '$dataDir'..."
 fi
 
 asyncRun() {

--- a/linux/9.2.0 rev. 002893/sitecore-xp-sql/boot.sh
+++ b/linux/9.2.0 rev. 002893/sitecore-xp-sql/boot.sh
@@ -4,7 +4,7 @@ cleanDir=$1
 dataDir=$2
 
 # prepare data
-if [ -z "$(ls -A $dataDir)" ]; then
+if ls $dataDir/*.mdf 1> /dev/null 2>&1; then
     echo "### No data found in '$dataDir', seeding..."
    
     cp -R --verbose $cleanDir/. $dataDir/


### PR DESCRIPTION
- Increased sqlcmd timeout values in case the SQL process is slow to start.
- Better checks for existing databases files in the attach script used when booting.