### PR TITLE
Easier use of registry from docker-compose test files

### DIFF
--- a/tests/7.5 rev. 150212/1803/docker-compose.standalone.yml
+++ b/tests/7.5 rev. 150212/1803/docker-compose.standalone.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   standalone:
-    image: sitecore:7.5.150212-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore:7.5.150212-windowsservercore-1803
     volumes:
       - .\data\standalone:C:\Sitecore
     ports:
@@ -21,7 +21,7 @@ services:
       - "27117:27017"
       
   sql:
-    image: sitecore-sqldev:7.5.150212-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-sqldev:7.5.150212-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB

--- a/tests/8.2 rev. 161221/1803/docker-compose.yml
+++ b/tests/8.2 rev. 161221/1803/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-sqldev:8.2.161221-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-sqldev:8.2.161221-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -19,7 +19,7 @@ services:
       - "44012:27017"
 
   cm:
-    image: sitecore:8.2.161221-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore:8.2.161221-windowsservercore-1803
     volumes:
       - .\data\cm:C:\Sitecore\Data\logs
     ports:

--- a/tests/8.2 rev. 170407/1803/docker-compose.standalone.yml
+++ b/tests/8.2 rev. 170407/1803/docker-compose.standalone.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   standalone:
-    image: sitecore:8.2.170407-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore:8.2.170407-windowsservercore-1803
     volumes:
       - .\data\standalone:C:\Sitecore
     ports:
@@ -21,7 +21,7 @@ services:
       - "27117:27017"
       
   sql:
-    image: sitecore-sqldev:8.2.170407-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-sqldev:8.2.170407-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB

--- a/tests/8.2 rev. 170614/1803/docker-compose.standalone.yml
+++ b/tests/8.2 rev. 170614/1803/docker-compose.standalone.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   standalone:
-    image: sitecore:8.2.170614-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore:8.2.170614-windowsservercore-1803
     volumes:
       - .\data\standalone:C:\Sitecore
     ports:
@@ -21,7 +21,7 @@ services:
       - "27117:27017"
       
   sql:
-    image: sitecore-sqldev:8.2.170614-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-sqldev:8.2.170614-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB

--- a/tests/9.0.1 rev. 180604/1803/docker-compose.xp.yml
+++ b/tests/9.0.1 rev. 180604/1803/docker-compose.xp.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-sqldev:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-sqldev:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44110:1433"
 
   solr:
-    image: sitecore-xp-solr:9.0.180604-nanoserver-1803
+    image: ${REGISTRY:-}sitecore-xp-solr:9.0.180604-nanoserver-1803
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44111:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-cd:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-cd:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-standalone:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-standalone:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.0.2 rev. 180604/1803/docker-compose.xm.yml
+++ b/tests/9.0.2 rev. 180604/1803/docker-compose.xm.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-sqldev:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-sqldev:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2000MB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-solr:9.0.180604-nanoserver-1803
+    image: ${REGISTRY:-}sitecore-solr:9.0.180604-nanoserver-1803
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1000MB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-cd:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xm1-cd:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
       
   cm:
-    image: sitecore-xm1-cm:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xm1-cm:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.0.2 rev. 180604/1803/docker-compose.xp.yml
+++ b/tests/9.0.2 rev. 180604/1803/docker-compose.xp.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-sqldev:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-sqldev:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.0.180604-nanoserver-1803
+    image: ${REGISTRY:-}sitecore-xp-solr:9.0.180604-nanoserver-1803
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-cd:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-cd:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-standalone:9.0.180604-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-standalone:9.0.180604-windowsservercore-1803
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.0.2 rev. 180604/ltsc2019/docker-compose.yml
+++ b/tests/9.0.2 rev. 180604/ltsc2019/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-sqldev:9.0.180604-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-sqldev:9.0.180604-windowsservercore-ltsc2019
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2000MB
@@ -11,7 +11,7 @@ services:
       - "44003:1433"
 
   solr:
-    image: sitecore-solr:9.0.180604-nanoserver-1809
+    image: ${REGISTRY:-}sitecore-solr:9.0.180604-nanoserver-1809
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1000MB
@@ -19,7 +19,7 @@ services:
       - "44002:8983"
 
   cm:
-    image: sitecore-xm1-cm:9.0.180604-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xm1-cm:9.0.180604-windowsservercore-ltsc2019
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.0 rev. 001564/1803/docker-compose.xm.yml
+++ b/tests/9.1.0 rev. 001564/1803/docker-compose.xm.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-sqldev:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xm1-sqldev:9.1.0-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.1.0-nanoserver-1803
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.1.0-nanoserver-1803
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-cd:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xm1-cd:9.1.0-windowsservercore-1803
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-cm:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xm1-cm:9.1.0-windowsservercore-1803
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.0 rev. 001564/1803/docker-compose.xp.yml
+++ b/tests/9.1.0 rev. 001564/1803/docker-compose.xp.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-sqldev:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-sqldev:9.1.0-windowsservercore-1803
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.1.0-nanoserver-1803
+    image: ${REGISTRY:-}sitecore-xp-solr:9.1.0-nanoserver-1803
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.1.0-windowsservercore-1803
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.1.0-windowsservercore-1803
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.1.0-windowsservercore-1803
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-cd:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-cd:9.1.0-windowsservercore-1803
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-standalone:9.1.0-windowsservercore-1803
+    image: ${REGISTRY:-}sitecore-xp-standalone:9.1.0-windowsservercore-1803
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.0 rev. 001564/ltsc2019/docker-compose.xm.yml
+++ b/tests/9.1.0 rev. 001564/ltsc2019/docker-compose.xm.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-sqldev:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xm1-sqldev:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.1.0-nanoserver-1809
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.1.0-nanoserver-1809
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-cd:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xm1-cd:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-cm:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xm1-cm:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.0 rev. 001564/ltsc2019/docker-compose.xp.yml
+++ b/tests/9.1.0 rev. 001564/ltsc2019/docker-compose.xp.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-sqldev:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xp-sqldev:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.1.0-nanoserver-1809
+    image: ${REGISTRY:-}sitecore-xp-solr:9.1.0-nanoserver-1809
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-cd:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xp-cd:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-standalone:9.1.0-windowsservercore-ltsc2019
+    image: ${REGISTRY:-}sitecore-xp-standalone:9.1.0-windowsservercore-ltsc2019
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.jss.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.jss.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-jss-11.0.1-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-jss-11.0.1-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.1.1-nanoserver-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.1.1-nanoserver-${windows_version}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-jss-11.0.1-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-jss-11.0.1-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-jss-11.0.1-cm:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-jss-11.0.1-cm:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.pse.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.pse.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.1.1-nanoserver-1809
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.1.1-nanoserver-1809
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-pse-5.0-cm:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-pse-5.0-cm:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.sxa.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.sxa.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-sxa-1.8.1-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-sxa-1.8.1-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.1.1-nanoserver-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.1.1-nanoserver-${windows_version}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-sxa-1.8.1-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-sxa-1.8.1-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-sxa-1.8.1-cm:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-sxa-1.8.1-cm:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
       - .\data\creativeexchange:C:\inetpub\sc\App_Data\packages\CreativeExchange\FileStorage

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xm.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.1.1-nanoserver-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.1.1-nanoserver-${windows_version}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-cm:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xm1-cm:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.jss.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.jss.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-jss-11.0.1-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-jss-11.0.1-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-jss-11.0.1-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-jss-11.0.1-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-jss-11.0.1-standalone:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-jss-11.0.1-standalone:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.pse.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.pse.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-pse-5.0-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-pse-5.0-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.sxa.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.sxa.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-sxa-1.8.1-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-sxa-1.8.1-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-sxa-1.8.1-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-sxa-1.8.1-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-sxa-1.8.1-standalone:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-sxa-1.8.1-standalone:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
       - .\data\creativeexchange:C:\inetpub\sc\App_Data\packages\CreativeExchange\FileStorage

--- a/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.yml
+++ b/tests/9.1.1 rev. 002459/windowsservercore/docker-compose.xp.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-sqldev:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-sqldev:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-solr:9.1.1-nanoserver-${windows_version}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-cd:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-cd:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-standalone:9.1.1-windowsservercore-${windows_version}
+    image: ${REGISTRY:-}sitecore-xp-standalone:9.1.1-windowsservercore-${windows_version}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xm.pse.yml
+++ b/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xm.pse.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-pse-5.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-pse-5.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-pse-5.0-cm:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-pse-5.0-cm:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xm.sxa.yml
+++ b/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xm.sxa.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-sxa-1.9.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-sxa-1.9.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-sxa-1.9.0-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-sxa-1.9.0-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-sxa-1.9.0-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-sxa-1.9.0-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-sxa-1.9.0-cm:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-sxa-1.9.0-cm:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
       - .\data\creativeexchange:C:\inetpub\sc\App_Data\packages\CreativeExchange\FileStorage

--- a/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xm.yml
+++ b/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xm.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xm1-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xm1-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   cd:
-    image: sitecore-xm1-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -29,7 +29,7 @@ services:
       - solr
 
   cm:
-    image: sitecore-xm1-cm:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xm1-cm:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xp.pse.yml
+++ b/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xp.pse.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-pse-5.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-pse-5.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-pse-5.0-standalone:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-pse-5.0-standalone:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
     ports:

--- a/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xp.sxa.yml
+++ b/tests/9.2.0 rev. 002893/windowsservercore/docker-compose.xp.sxa.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   sql:
-    image: sitecore-xp-sxa-1.9.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-sxa-1.9.0-sqldev:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\sql:C:\Data
     mem_limit: 2GB
@@ -11,7 +11,7 @@ services:
       - "44010:1433"
 
   solr:
-    image: sitecore-xp-sxa-1.9.0-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-sxa-1.9.0-solr:9.2.0-nanoserver-${NANOSERVER_CHANNEL}
     volumes:
       - .\data\solr:C:\Data
     mem_limit: 1GB
@@ -19,7 +19,7 @@ services:
       - "44011:8983"
 
   xconnect:
-    image: sitecore-xp-xconnect:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-xconnect:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
     mem_limit: 1GB
@@ -28,7 +28,7 @@ services:
       - solr
 
   xconnect-automationengine:
-    image: sitecore-xp-xconnect-automationengine:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-automationengine:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
     mem_limit: 500MB
@@ -37,7 +37,7 @@ services:
       - xconnect
 
   xconnect-indexworker:
-    image: sitecore-xp-xconnect-indexworker:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-xconnect-indexworker:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
     mem_limit: 500MB
@@ -46,7 +46,7 @@ services:
       - solr
 
   cd:
-    image: sitecore-xp-sxa-1.9.0-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-sxa-1.9.0-cd:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cd:C:\inetpub\sc\App_Data\logs
     ports:
@@ -57,7 +57,7 @@ services:
       - xconnect
 
   cm:
-    image: sitecore-xp-sxa-1.9.0-standalone:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
+    image: ${REGISTRY:-}sitecore-xp-sxa-1.9.0-standalone:9.2.0-windowsservercore-${WINDOWSSERVERCORE_CHANNEL}
     volumes:
       - .\data\cm:C:\inetpub\sc\App_Data\logs
       - .\data\creativeexchange:C:\inetpub\sc\App_Data\packages\CreativeExchange\FileStorage


### PR DESCRIPTION
This pull request adds ``${REGISTRY:-}`` prefix to image references in the docker-compose files located in the ``tests/`` folder

This allows consumers to use an environment variable to specify a registry you want to use.
If no such variable is available the current behavior (local images only) will be preserved

The variable must end with a slash. Eg. when images are built with ``-Registry hub.docker.com/org`` you would set the environment variable as
```cmd
setx REGISTRY hub.docker.com/org/
```
