### PR TITLE
Feature/make registry optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## October 2019
+
+- [Changed] Made the $Registry parameter optional. Not specifying the $Registry will build the images locally only.
+
 ## September 2019
 
 - [Fixed] Invalid download url in `sitecore-packages.json` was fixed for JSS 11.0.1 XP CM. **IMPORTANT**: Remove the file `Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318.scwdp.zip` from where you store the packages and **ALSO** also inside `.\variants\9.1.1\windowsservercore\jss\sitecore-xp-jss-11.0.1-standalone\` so the package will be re-downloaded.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here is the convention used when tagging images:
 
 ### Prerequisites
 
-- A **private** Docker repository. Any will do, but the easiest is to use a [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/) or to sign-up for a private plan on [https://hub.docker.com](https://hub.docker.com), you need at least the "Small" plan at $12/mo.
+- *Now Optional* - A **private** Docker repository. Any will do, but the easiest is to use a [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/) or to sign-up for a private plan on [https://hub.docker.com](https://hub.docker.com), you need at least the "Small" plan at $12/mo.
 - A file share that your build agents can reach, where you have placed zip files downloaded from [https://dev.sitecore.net/](https://dev.sitecore.net/) **and** your license.xml.
 - Some kind of build server for example TeamCity, with agents that runs:
   - Windows 10 or Windows Server 2016 that is up to date and on latest build.
@@ -65,7 +65,7 @@ Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -Force
 
 # Settings
 $installSourcePath = (Join-Path $PSScriptRoot "\packages") # PATH TO WHERE YOU KEEP ALL SITECORE ZIP FILES AND LICENSE.XML, can be on local machine or a file share.
-$registry = "YOUR REGISTRY NAME" ` # On Docker Hub it's your username or organization, else it's the hostname of your own registry.
+$registry = "YOUR REGISTRY NAME" ` # On Docker Hub it's your username or organization, else it's the hostname of your own registry. Note that this parameter is now optional.
 $sitecoreUsername = "YOUR dev.sitecore.net USERNAME"
 $sitecorePassword = "YOUR dev.sitecore.net PASSWORD"
 

--- a/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
+++ b/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
@@ -126,7 +126,6 @@ function Invoke-Build
         [ValidateScript( { Test-Path $_ -PathType "Container" })] 
         [string]$InstallSourcePath
         ,
-        [Parameter(Mandatory = $true)]
         [string]$Registry
         ,
         [Parameter(Mandatory = $false)]
@@ -246,8 +245,14 @@ function Invoke-Build
             $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw "Failed: $buildCommand" }
 
             # Tag image
-            $fulltag = "{0}/{1}" -f $Registry, $tag
-
+            if ($null -eq $Registry)
+            {
+                $fulltag = "{0}" -f $tag
+            }
+            else 
+            {
+                $fulltag = "{0}/{1}" -f $Registry, $tag
+            }
             docker image tag $tag $fulltag
 
             $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw "Failed." }

--- a/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
+++ b/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
@@ -245,9 +245,10 @@ function Invoke-Build
             $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw "Failed: $buildCommand" }
 
             # Tag image
-            if ($null -eq $Registry)
+            if ([string]::IsNullOrEmpty($Registry))
             {
-                $fulltag = "{0}" -f $tag
+                $fulltag = $tag
+                $PushMode = "Never"
             }
             else 
             {


### PR DESCRIPTION
Closes #79 

Made it possible to omit the $Registry parameter making it possible for anyone to build the images locally without first setting up a private Docker registry.