### PR TITLE
Fix Sitecore Download Session variable issue

### DIFF
--- a/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
+++ b/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
@@ -101,18 +101,13 @@ function Invoke-PackageRestore
                         username   = $SitecoreUsername
                         password   = $SitecorePassword
                         rememberMe = $true
-                    } -SessionVariable "downloadSession" -UseBasicParsing
+                    } -SessionVariable "sitecoreDownloadSession" -UseBasicParsing
 
                     if ($null -eq $loginResponse -or $loginResponse.StatusCode -ne 200 -or $loginResponse.Content -eq "false")
                     {
                         throw ("Unable to login to '{0}' with the supplied credentials." -f $sitecoreDownloadUrl)
                     }
-                    else
-                    {
-                        # Assign the downloadSession variable back to sitecoreDownloadSession to use in package download - Line 120
-                        $sitecoreDownloadSession = $downloadSession 
-                    }
-
+                    
                     Write-Verbose ("Logged in to '{0}'." -f $sitecoreDownloadUrl)
                 }
 

--- a/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
+++ b/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
@@ -107,6 +107,11 @@ function Invoke-PackageRestore
                     {
                         throw ("Unable to login to '{0}' with the supplied credentials." -f $sitecoreDownloadUrl)
                     }
+                    else
+                    {
+                        # Assign the downloadSession variable back to sitecoreDownloadSession to use in package download - Line 120
+                        $sitecoreDownloadSession = $downloadSession 
+                    }
 
                     Write-Verbose ("Logged in to '{0}'." -f $sitecoreDownloadUrl)
                 }


### PR DESCRIPTION
In line 104, string `downloadSession` is used for SessionVariable of Invoke_webRequest. But this was not assigned back to `$sitecoreDownloadSession` which is used in actual package download. Due to this receiving asp.net customerror page response