### PR TITLE
JSS docker images are missing the web.config changes which should be …

### DIFF
--- a/windows/9.2.x/sitecore-xm-jss/Dockerfile
+++ b/windows/9.2.x/sitecore-xm-jss/Dockerfile
@@ -11,8 +11,10 @@ ARG ASSETS_USE_WDP
 
 COPY --from=assets ["${ASSETS_USE_WDP}", "C:\\temp\\packages\\"]
 
-# expand selected wdp into installation directory
+# expand selected wdp, inlcuding .xdt transformation files from the SCCPL package (`Expand-Archive` command needs it to be renamed to .zip file), into installation directory
 RUN Expand-Archive -Path 'C:\\temp\\packages\\*.zip' -DestinationPath 'C:\\temp'; `
+    Rename-Item -Path 'C:\\temp\\Content\\Website\\App_Data\\Transforms\\JSSSCCPL.sccpl' -NewName 'JSSSCCPL.sccpl.zip';`
+    Expand-Archive -Path 'C:\\temp\\Content\\Website\\App_Data\\Transforms\\JSSSCCPL.sccpl.zip' -DestinationPath 'C:\\temp\\Content\\Website\\App_Data\\JssXdt';`
     Copy-Item -Path 'C:\\temp\\Content\\Website\\*' -Destination 'C:\\inetpub\\wwwroot' -Recurse -Force;
 
 # copy tools and transforms

--- a/windows/9.2.x/sitecore-xp-jss/Dockerfile
+++ b/windows/9.2.x/sitecore-xp-jss/Dockerfile
@@ -11,9 +11,18 @@ ARG ASSETS_USE_WDP
 
 COPY --from=assets ["${ASSETS_USE_WDP}", "C:\\temp\\packages\\"]
 
-# expand selected wdp into installation directory
+# expand selected wdp, inlcuding .xdt transformation files from the SCCPL package (`Expand-Archive` command needs it to be renamed to .zip file), into installation directory
 RUN Expand-Archive -Path 'C:\\temp\\packages\\*.zip' -DestinationPath 'C:\\temp'; `
+    Rename-Item -Path 'C:\\temp\\Content\\Website\\App_Data\\Transforms\\JSSSCCPL.sccpl' -NewName 'JSSSCCPL.sccpl.zip';`
+    Expand-Archive -Path 'C:\\temp\\Content\\Website\\App_Data\\Transforms\\JSSSCCPL.sccpl.zip' -DestinationPath 'C:\\temp\\Content\\Website\\App_Data\\JssXdt';`
     Copy-Item -Path 'C:\\temp\\Content\\Website\\*' -Destination 'C:\\inetpub\\wwwroot' -Recurse -Force;
+
+# copy tools and transforms
+COPY --from=assets ["C:\\install\\tools\\", "C:\\install\\tools\\"]
+
+# find transform files and do transformation
+RUN (Get-ChildItem -Path 'C:\\inetpub\\wwwroot\\*.xdt' -Recurse ) | ForEach-Object { & 'C:\\install\\tools\\scripts\\Invoke-XdtTransform.ps1' -Path 'C:\\inetpub\\wwwroot\\web.config' -XdtPath $_.FullName -XdtDllPath 'C:\\install\\tools\\bin\\Microsoft.Web.XmlTransform.dll'; }; 
+
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
…applied by the XDT files from the SCCPL of Azure's WDP #122

 - Extract .xdt files from `\Sitecore JavaScript Services Server for Sitecore 9.2 XM 12.0.0 rev. 190522.scwdp.zip\Content\Website\App_Data\Transforms\JSSSCCPL.sccpl` to `\Website\App_Data\JssXdt\` so that the .xdt files can be picked-up by the transformation script.