### PR TITLE
Install Node.js for JSS images for Experience Editor

### DIFF
--- a/windows/9.2.0/sitecore-assets/Dockerfile
+++ b/windows/9.2.0/sitecore-assets/Dockerfile
@@ -12,7 +12,8 @@ RUN New-Item -Path 'C:\\downloads' -ItemType 'Directory' -Force | Out-Null; `
     & curl.exe -sS -L -o C:\\downloads\\urlrewrite.msi https://download.microsoft.com/download/1/2/8/128E2E22-C1B9-44A4-BE2A-5859ED1D4592/rewrite_amd64_en-US.msi; `
     & curl.exe -sS -L -o C:\\downloads\\vc_redist.exe https://aka.ms/vs/15/release/VC_redist.x64.exe; `
     & curl.exe -sS -L -o C:\\downloads\\filebeat.zip https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.4.1-windows-x86_64.zip; `
-    & curl.exe -sS -L -o C:\\downloads\\dotnet-hosting.exe https://download.visualstudio.microsoft.com/download/pr/34f4b2a6-c3b8-495c-a11f-6db955f27757/8c340c1a8c25966e39e0c0a4b308dff4/dotnet-hosting-2.2.5-win.exe;
+    & curl.exe -sS -L -o C:\\downloads\\dotnet-hosting.exe https://download.visualstudio.microsoft.com/download/pr/34f4b2a6-c3b8-495c-a11f-6db955f27757/8c340c1a8c25966e39e0c0a4b308dff4/dotnet-hosting-2.2.5-win.exe; `
+    & curl.exe -sS -L -o c:\\downloads\\node.msi https://nodejs.org/dist/v12.13.0/node-v12.13.0-x64.msi;
 
 # copy local assets
 COPY *.zip C:\\downloads\\

--- a/windows/9.2.x/sitecore-xm-jss/Dockerfile
+++ b/windows/9.2.x/sitecore-xm-jss/Dockerfile
@@ -27,5 +27,15 @@ FROM $BASE_IMAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+ARG SC_ROLE_DEFINE
+
 COPY --from=build ["C:\\inetpub\\wwwroot\\", "C:\\inetpub\\wwwroot\\"]
 
+# copy Node.JS installer
+COPY --from=assets ["C:\\install\\setup\\node.msi", "C:\\inetpub\\wwwroot\\temp\\install\\setup\\node.msi"]
+
+RUN $env:INSTALL_TEMP = 'C:\\inetpub\\wwwroot\\temp\\install'; `
+    # setup Node.JS for Experience Editor
+    if (($env:SC_ROLE_DEFINE -like '*ContentManagement*') -or ($env:SC_ROLE_DEFINE -like '*Standalone*')) `
+    { Start-Process msiexec.exe -ArgumentList '/i', (Join-Path $env:INSTALL_TEMP '\\setup\\node.msi'), '/quiet', '/norestart' -NoNewWindow -Wait; } ` 
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse;

--- a/windows/9.2.x/sitecore-xm-jss/build.json
+++ b/windows/9.2.x/sitecore-xm-jss/build.json
@@ -5,7 +5,8 @@
       "build-options": [
         "--build-arg BASE_IMAGE=sitecore-xm-cm:9.2.0-windowsservercore-${windowsservercore_version}",
         "--build-arg ASSETS_IMAGE=sitecore-assets:9.2.0-nanoserver-${nanoserver_version}",
-        "--build-arg ASSETS_USE_WDP='C:\\packages\\Sitecore JavaScript Services Server for Sitecore 9.2 XM 12.0.0 rev. 190522.scwdp.zip'"
+        "--build-arg ASSETS_USE_WDP='C:\\packages\\Sitecore JavaScript Services Server for Sitecore 9.2 XM 12.0.0 rev. 190522.scwdp.zip'",
+        "--build-arg SC_ROLE_DEFINE='ContentManagement'"
       ]
     },
     {

--- a/windows/9.2.x/sitecore-xp-jss/Dockerfile
+++ b/windows/9.2.x/sitecore-xp-jss/Dockerfile
@@ -28,4 +28,15 @@ FROM $BASE_IMAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+ARG SC_ROLE_DEFINE
+
 COPY --from=build ["C:\\inetpub\\wwwroot\\", "C:\\inetpub\\wwwroot\\"]
+
+# copy Node.JS installer
+COPY --from=assets ["C:\\install\\setup\\node.msi", "C:\\inetpub\\wwwroot\\temp\\install\\setup\\node.msi"]
+
+RUN $env:INSTALL_TEMP = 'C:\\inetpub\\wwwroot\\temp\\install'; `
+    # setup Node.JS for Experience Editor
+    if (($env:SC_ROLE_DEFINE -like '*ContentManagement*') -or ($env:SC_ROLE_DEFINE -like '*Standalone*')) `
+    { Start-Process msiexec.exe -ArgumentList '/i', (Join-Path $env:INSTALL_TEMP '\\setup\\node.msi'), '/quiet', '/norestart' -NoNewWindow -Wait; } ` 
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse;

--- a/windows/9.2.x/sitecore-xp-jss/build.json
+++ b/windows/9.2.x/sitecore-xp-jss/build.json
@@ -5,7 +5,8 @@
       "build-options": [
         "--build-arg BASE_IMAGE=sitecore-xp-standalone:9.2.0-windowsservercore-${windowsservercore_version}",
         "--build-arg ASSETS_IMAGE=sitecore-assets:9.2.0-nanoserver-${nanoserver_version}",
-        "--build-arg ASSETS_USE_WDP='C:\\packages\\Sitecore JavaScript Services Server for Sitecore 9.2 XP 12.0.0 rev. 190522.scwdp.zip'"
+        "--build-arg ASSETS_USE_WDP='C:\\packages\\Sitecore JavaScript Services Server for Sitecore 9.2 XP 12.0.0 rev. 190522.scwdp.zip'",
+        "--build-arg SC_ROLE_DEFINE='Standalone'"
       ]
     },
     {


### PR DESCRIPTION
- Download Node.js in the assets image
- Update _sitecore-xm-jss_ and _sitecore-xp-jss_ Dockerfiles to install Node.js for _ContentManagement_ and _Standalone_ roles

Fixes #130 