### PR TITLE
Certificate naming issue

### DIFF
--- a/windows/9.2.x/sitecore-xc/Dockerfile
+++ b/windows/9.2.x/sitecore-xc/Dockerfile
@@ -62,7 +62,7 @@ RUN $env:INSTALL_TEMP = 'C:\\inetpub\\wwwroot\\temp\\install'; `
     Import-PfxCertificate -FilePath (Join-Path $env:INSTALL_TEMP '\\certificates\\commerce-client.pfx') -CertStoreLocation 'cert:\localmachine\my' -Password $password | Out-Null; `
     # configure SSL binding because Commerce Engine requires HTTPS (see Sitecore ticket #542018)
     Import-Module WebAdministration; `
-    $xcCert = Import-PfxCertificate -FilePath (Join-Path $env:INSTALL_TEMP '\\certificates\\xc.pfx') -CertStoreLocation 'cert:\localmachine\my' -Password $password; `
+    $xcCert = Import-PfxCertificate -FilePath (Join-Path $env:INSTALL_TEMP '\\certificates\\cm.pfx') -CertStoreLocation 'cert:\localmachine\my' -Password $password; `
     New-WebBinding -Name $env:IIS_SITE_NAME -IPAddress '*' -Port '443' -Protocol "https" -HostHeader '*'; `
     $binding = Get-WebBinding -Name $env:IIS_SITE_NAME -Protocol "https"; `
     $binding.AddSslCertificate($xcCert.GetCertHashString(), 'my'); `

--- a/windows/9.2.x/sitecore-xc/Dockerfile
+++ b/windows/9.2.x/sitecore-xc/Dockerfile
@@ -62,10 +62,10 @@ RUN $env:INSTALL_TEMP = 'C:\\inetpub\\wwwroot\\temp\\install'; `
     Import-PfxCertificate -FilePath (Join-Path $env:INSTALL_TEMP '\\certificates\\commerce-client.pfx') -CertStoreLocation 'cert:\localmachine\my' -Password $password | Out-Null; `
     # configure SSL binding because Commerce Engine requires HTTPS (see Sitecore ticket #542018)
     Import-Module WebAdministration; `
-    $xcCert = Import-PfxCertificate -FilePath (Join-Path $env:INSTALL_TEMP '\\certificates\\cm.pfx') -CertStoreLocation 'cert:\localmachine\my' -Password $password; `
+    $cmCert = Import-PfxCertificate -FilePath (Join-Path $env:INSTALL_TEMP '\\certificates\\cm.pfx') -CertStoreLocation 'cert:\localmachine\my' -Password $password; `
     New-WebBinding -Name $env:IIS_SITE_NAME -IPAddress '*' -Port '443' -Protocol "https" -HostHeader '*'; `
     $binding = Get-WebBinding -Name $env:IIS_SITE_NAME -Protocol "https"; `
-    $binding.AddSslCertificate($xcCert.GetCertHashString(), 'my'); `
+    $binding.AddSslCertificate($cmCert.GetCertHashString(), 'my'); `
     # configure SSL flags
     Set-WebConfigurationProperty -PSPath 'machine/webroot/apphost' -Filter 'system.webServer/security/access' -Name 'sslFlags' -Value 'SslNegotiateCert'; `
     # delete temporary files

--- a/windows/dependencies/sitecore-certificates/Dockerfile
+++ b/windows/dependencies/sitecore-certificates/Dockerfile
@@ -12,7 +12,7 @@ RUN $env:ROOT_CERT_NAME = 'sitecore-root'; `
     $env:COMMERCE_CLIENT_CERT_NAME = 'commerce-client'; `
     $env:IDENTITY_CLIENT_CERT_NAME = 'identity-client'; `
     $env:IDENTITY_SSL_CERT_NAME = 'identity'; `
-    $env:XC_SSL_CERT_NAME = 'cm'; `
+    $env:CM_SSL_CERT_NAME = 'cm'; `
     $env:CERT_STORE = 'Cert:\LocalMachine\My'; `
     $env:CERT_PASSWORD = 'Twelve4-4Cranial-Rag-kayo4-Ragweed-This8-grunge9-0Foss-7finalist-hubby'; `
     New-Item -Path 'C:\\certificates' -ItemType 'Directory' | Out-Null; `
@@ -24,7 +24,7 @@ RUN $env:ROOT_CERT_NAME = 'sitecore-root'; `
     New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:COMMERCE_CLIENT_CERT_NAME -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:COMMERCE_CLIENT_CERT_NAME) -Password $password | Out-Null; `
     New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:IDENTITY_CLIENT_CERT_NAME -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:IDENTITY_CLIENT_CERT_NAME) -Password $password | Out-Null; `
     New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:IDENTITY_SSL_CERT_NAME, '127.0.0.1', 'localhost' -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:IDENTITY_SSL_CERT_NAME) -Password $password | Out-Null; `
-    New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:XC_SSL_CERT_NAME, '127.0.0.1', 'localhost' -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:XC_SSL_CERT_NAME) -Password $password | Out-Null; `
+    New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:CM_SSL_CERT_NAME, '127.0.0.1', 'localhost' -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:CM_SSL_CERT_NAME) -Password $password | Out-Null; `
     Import-PfxCertificate -FilePath ('C:\\certificates\\sitecore-root.pfx') -CertStoreLocation 'cert:\localmachine\root' -Password $password | Out-Null; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:ROOT_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:ROOT_CERT_NAME) -NoNewline -Encoding utf8; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:XCONNECT_SSL_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:XCONNECT_SSL_CERT_NAME) -NoNewline -Encoding utf8; `
@@ -32,7 +32,7 @@ RUN $env:ROOT_CERT_NAME = 'sitecore-root'; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:COMMERCE_CLIENT_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:COMMERCE_CLIENT_CERT_NAME) -NoNewline -Encoding utf8; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:IDENTITY_CLIENT_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:IDENTITY_CLIENT_CERT_NAME) -NoNewline -Encoding utf8; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:IDENTITY_SSL_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:IDENTITY_SSL_CERT_NAME) -NoNewline -Encoding utf8; `
-    (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:XC_SSL_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:XC_SSL_CERT_NAME) -NoNewline -Encoding utf8; `
+    (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:CM_SSL_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:CM_SSL_CERT_NAME) -NoNewline -Encoding utf8; `
     $env:CERT_PASSWORD | Out-File -FilePath 'C:\\certificates\\password' -NoNewline -Encoding utf8;
 
 FROM $BASE_IMAGE

--- a/windows/dependencies/sitecore-certificates/Dockerfile
+++ b/windows/dependencies/sitecore-certificates/Dockerfile
@@ -12,7 +12,7 @@ RUN $env:ROOT_CERT_NAME = 'sitecore-root'; `
     $env:COMMERCE_CLIENT_CERT_NAME = 'commerce-client'; `
     $env:IDENTITY_CLIENT_CERT_NAME = 'identity-client'; `
     $env:IDENTITY_SSL_CERT_NAME = 'identity'; `
-    $env:XC_SSL_CERT_NAME = 'xc'; `
+    $env:XC_SSL_CERT_NAME = 'cm'; `
     $env:CERT_STORE = 'Cert:\LocalMachine\My'; `
     $env:CERT_PASSWORD = 'Twelve4-4Cranial-Rag-kayo4-Ragweed-This8-grunge9-0Foss-7finalist-hubby'; `
     New-Item -Path 'C:\\certificates' -ItemType 'Directory' | Out-Null; `


### PR DESCRIPTION
The certificate name being used for CM was incorrectly named 'XC'.

This means that the engine couldn't not create an SSL connection to https://cm as the cert name didn't match.

Changing this allows the commerce engine to talk to the CM instance.