### PR TITLE
First iteration of publishing service image (v4.1)

### DIFF
--- a/sitecore-packages.json
+++ b/sitecore-packages.json
@@ -310,5 +310,9 @@
   },
   "Sitecore Experience Accelerator XM 9.3.0.2589 CD.scwdp.zip": {
     "url": "https://dev.sitecore.net/~/media/66D1C7AE0D884BA38D16E9A01C2C38E2.ashx"
+  },
+  "Sitecore Publishing Service 4.1.0-x64.zip" : {
+    "description": "Sitecore Publishing Service 4.1.0",
+    "url": "https://dev.sitecore.net/~/media/51A8BC4DDAC647F18DF67A8EC1B37AE0.ashx"
   }
 }

--- a/windows/pub-svc-4.1.0/Dockerfile
+++ b/windows/pub-svc-4.1.0/Dockerfile
@@ -1,0 +1,30 @@
+# escape=`
+ARG BASE_IMAGE
+
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8
+
+ARG PUBLISHING_SITE_NAME=sitecore.publishing
+ENV INSTALL_PATH="c:\\install"
+ARG PUBLISHING_PACKAGE="Sitecore Publishing Service 4.1.0-x64.zip"
+ARG PUBLISHING_PACKAGE_PATH=${INSTALL_PATH}\\${PUBLISHING_PACKAGE}
+ENV DOTNETCOREHOSTING_EXE=${INSTALL_PATH}\\DotNetCore.1.1.0-WindowsHosting.exe
+ADD https://aka.ms/dotnetcore_windowshosting_1_1_0 ${DOTNETCOREHOSTING_EXE}
+
+SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+RUN Start-Process $env:DOTNETCOREHOSTING_EXE -ArgumentList '/install', '/passive', '/norestart' -NoNewWindow -Wait; 
+
+RUN Import-Module ServerManager; `
+	Add-WindowsFeature Web-Scripting-Tools; `
+	Remove-Website -Name 'Default Web Site';
+
+COPY . ${INSTALL_PATH}
+
+WORKDIR "C:\\inetpub\\wwwroot\\publisher"
+
+RUN	Expand-Archive -Path $env:PUBLISHING_PACKAGE_PATH -DestinationPath .; 
+
+RUN $args = 'iis install --sitename ' + $env:PUBLISHING_SITE_NAME + ' --apppool ' + $env:PUBLISHING_SITE_NAME; `
+	Start-Process "Sitecore.Framework.Publishing.Host.exe" -ArgumentList $args -NoNewWindow -Wait; 
+
+EXPOSE 80

--- a/windows/pub-svc-4.1.0/build.json
+++ b/windows/pub-svc-4.1.0/build.json
@@ -1,0 +1,14 @@
+{
+  "tags": [
+    {
+      "tag": "pubsvc:4.1.0-windowsservercore-${windowsservercore_version}",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-${windowsservercore_version}"
+      ]
+    }
+  ],
+  "sources": [
+    "Sitecore Publishing Service 4.1.0-x64.zip"
+  ]
+}
+

--- a/windows/pub-svc-4.1.0/entrypoints/Boot.ps1
+++ b/windows/pub-svc-4.1.0/entrypoints/Boot.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+ param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    $ConnectionString_Core,
+    $ConnectionString_Master, 
+    $ConnectionString_Web,
+    $PublishingHost = 'Sitecore.Framework.Publishing.Host.exe'
+)
+
+$coreArgs = 'configuration setconnectionstring core "' + $ConnectionString_Core + '"'; 
+$masterArgs = 'configuration setconnectionstring master "' + $ConnectionString_Master + '"'; 
+$webArgs = 'configuration setconnectionstring web "' + $ConnectionString_Web + '"'; 
+
+Start-Process $PublishingHost -ArgumentList $coreArgs -NoNewWindow -Wait;  
+Start-Process $PublishingHost -ArgumentList $masterArgs -NoNewWindow -Wait;  
+Start-Process $PublishingHost -ArgumentList $webArgs -NoNewWindow -Wait; 
+
+Start-Process $PublishingHost -ArgumentList 'schema upgrade --force' -NoNewWindow -Wait; 
+
+Write-Output "Starting ServiceMonitor.exe"
+
+& C:\ServiceMonitor.exe "w3svc"

--- a/windows/tests/pubsvc 4.1.0/.env
+++ b/windows/tests/pubsvc 4.1.0/.env
@@ -1,0 +1,4 @@
+WINDOWSSERVERCORE_VERSION=1903
+conn_string_core="Data Source=(local);Database=SitecoreCore;User Id=sitecore;Password=sitecore;"
+conn_string_master="Data Source=(local);Database=SitecoreMaster;User Id=sitecore;Password=sitecore;"
+conn_string_web="Data Source=(local);Database=SitecoreWeb;User Id=sitecore;Password=sitecore;"

--- a/windows/tests/pubsvc 4.1.0/docker-compose.yml
+++ b/windows/tests/pubsvc 4.1.0/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2.4'
+services:
+  web:
+    image: pubsvc:4.1.0-windowsservercore-${windowsservercore_version}
+    container_name: publishingservice
+    entrypoint: powershell.exe -NoLogo -NoProfile -File c:\\install\\entrypoints\\Boot.ps1
+    command: ${conn_string_core} ${conn_string_master} ${conn_string_web}


### PR DESCRIPTION
Initial version of Publishing Service images.

Connection strings configurable in env file allowing one image to serve multiple Sitecore databases without rebuilding.

Jean Francois asked me to raise this PR a while back, please let me know any comments, suggestions or improvements you have