### PR TITLE
#150 Remove code that updates ShardsGlobal and ShardsLocal

### DIFF
--- a/windows/9.3.x/sitecore-xp-sqldev/Boot.ps1
+++ b/windows/9.3.x/sitecore-xp-sqldev/Boot.ps1
@@ -39,11 +39,7 @@ Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
 
 Write-Host "### Preparing Sitecore databases..."
 
-# See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
 Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''Sitecore'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'")
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{0}'" -f $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{0}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{0}'" -f $env:DB_PREFIX, $SqlHostname)
 
 Write-Host "### Sitecore databases ready!"
 


### PR DESCRIPTION
Compose file docker-compose.xp.yml doesn't work
Reason: SQL container could not start, because of error during exection SQL script UPDATE [Sitecore.Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal]  ....

As ShardsGlobal and ShardsLocal exist only in Azure configuration(shard0_azure.sql and shard1_azure.sql files), I think it should be safe to get rid from this code