### PR TITLE
Fix: recursively copy tools for xc-engine and bizfx & development/production.ps1 fix

### DIFF
--- a/windows/9.2.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -119,8 +119,10 @@ else
     Write-Host ("### Skipping start of 'WatchDirectory.ps1', to enable you should mount a directory into 'C:\src'.")
 }
 
-# inject Sitecore config files
-Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
+if (Test-Path -Path "C:\inetput\wwwroot\App_Config\Include") {
+    # inject Sitecore config files
+    Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
+}
 
 # start ServiceMonitor.exe in background, kill foreground process if it fails
 Start-Job -Name "ServiceMonitor.exe" {

--- a/windows/9.2.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
@@ -78,8 +78,10 @@ while ($true)
 # wait for application pool to stop
 Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Stopped"
 
-# inject Sitecore config files
-Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
+if (Test-Path -Path "C:\inetput\wwwroot\App_Config\Include") {
+    # inject Sitecore config files
+    Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
+}
 
 # start ServiceMonitor.exe in background, kill foreground process if it fails
 Start-Job -Name "ServiceMonitor.exe" {

--- a/windows/9.2.x/sitecore-xc-bizfx/Dockerfile
+++ b/windows/9.2.x/sitecore-xc-bizfx/Dockerfile
@@ -39,7 +39,7 @@ RUN $env:INSTALL_TEMP = 'C:\\inetpub\\wwwroot\\temp\\install'; `
     Start-Process msiexec.exe -ArgumentList '/i', (Join-Path $env:INSTALL_TEMP '\\setup\\urlrewrite.msi'), '/quiet', '/norestart' -NoNewWindow -Wait; `
     Start-Process (Join-Path $env:INSTALL_TEMP '\\setup\\vc_redist.exe') -ArgumentList '/install', '/passive', '/norestart' -NoNewWindow -Wait; `
     # install tools
-    Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\tools') -Destination 'C:\\tools' -Force; `
+    Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\tools') -Destination 'C:\\tools' -Recurse -Force; `
     setx /M PATH $($env:PATH + ';C:\tools\scripts;C:\tools\bin') | Out-Null; `
     # install certificates
     $password = ConvertTo-SecureString -String (Get-Content -Path (Join-Path $env:INSTALL_TEMP '\\certificates\\password')) -Force -AsPlainText; `

--- a/windows/9.2.x/sitecore-xc-engine/Dockerfile
+++ b/windows/9.2.x/sitecore-xc-engine/Dockerfile
@@ -49,7 +49,7 @@ RUN $env:INSTALL_TEMP = 'C:\\inetpub\\wwwroot\\temp\\install'; `
     Start-Process (Join-Path $env:INSTALL_TEMP '\\setup\\vc_redist.exe') -ArgumentList '/install', '/passive', '/norestart' -NoNewWindow -Wait; `
     Start-Process (Join-Path $env:INSTALL_TEMP '\\setup\\dotnet-hosting.exe') -ArgumentList '/install', '/quiet' -NoNewWindow -Wait; `
     # install tools
-    Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\tools') -Destination 'C:\\tools' -Force; `
+    Copy-Item -Path (Join-Path $env:INSTALL_TEMP '\\tools') -Destination 'C:\\tools' -Recurse -Force; `
     setx /M PATH $($env:PATH + ';C:\tools\scripts;C:\tools\bin;C:\Program Files\dotnet') | Out-Null; `
     # install certificates
     $password = ConvertTo-SecureString -String (Get-Content -Path (Join-Path $env:INSTALL_TEMP '\\certificates\\password')) -Force -AsPlainText; `

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -119,9 +119,10 @@ else
     Write-Host ("### Skipping start of 'WatchDirectory.ps1', to enable you should mount a directory into 'C:\src'.")
 }
 
-# inject Sitecore config files
-Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
-
+if (Test-Path -Path "C:\inetput\wwwroot\App_Config\Include") {
+    # inject Sitecore config files
+    Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
+}
 # start ServiceMonitor.exe in background, kill foreground process if it fails
 Start-Job -Name "ServiceMonitor.exe" {
     try

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
@@ -78,8 +78,10 @@ while ($true)
 # wait for application pool to stop
 Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Stopped"
 
-# inject Sitecore config files
-Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
+if (Test-Path -Path "C:\inetput\wwwroot\App_Config\Include") {
+    # inject Sitecore config files
+    Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
+}
 
 # start ServiceMonitor.exe in background, kill foreground process if it fails
 Start-Job -Name "ServiceMonitor.exe" {


### PR DESCRIPTION
The xc-engine and bizfx did not deep copy the tools directory, and where therefore missing e.g. the entrypoint tools.

In addition a small fix for `development.ps1` and `production.ps1` to not exit when there is no `App_Config\Include` directory present (which is e.g. the case for xc-engine).