### PR TITLE
Adding development.ps1 entrypoint for xConnect worker images

### DIFF
--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
@@ -1,0 +1,33 @@
+# setup
+$ErrorActionPreference = "STOP"
+
+# print start message
+Write-Host ("### Sitecore Development ENTRYPOINT, starting...")
+
+# check to see if we should start the Watch-Directory.ps1 script
+$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+
+if ($useWatchDirectory)
+{
+    # start Watch-Directory.ps1 in background, kill foreground process if it fails
+    Start-Job -Name "WatchDirectory.ps1" {
+        try
+        {
+            # TODO: Handle additional Watch-Directory params, use param splattering?
+
+            & "C:\tools\scripts\Watch-Directory.ps1" -Path "C:\src" -Destination "C:\worker" -ExcludeFiles "Web.config"
+        }
+        finally
+        {
+            Get-Process -Name "filebeat" | Stop-Process -Force
+        }
+    } | ForEach-Object {
+        Write-Host ("### Started '$($_.Name)'.")
+    }
+}
+else
+{
+    Write-Host ("### Skipping start of 'WatchDirectory.ps1', to enable you should mount a directory into 'C:\src'.")
+}
+
+& C:\\worker\\$($env:SC_ROLE_EXE)

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
@@ -11,16 +11,11 @@ if ($useWatchDirectory)
 {
     # start Watch-Directory.ps1 in background, kill foreground process if it fails
     Start-Job -Name "WatchDirectory.ps1" {
-        try
-        {
-            # TODO: Handle additional Watch-Directory params, use param splattering?
 
-            & "C:\tools\scripts\Watch-Directory.ps1" -Path "C:\src" -Destination "C:\worker" -ExcludeFiles "Web.config"
-        }
-        finally
-        {
-            Get-Process -Name "filebeat" | Stop-Process -Force
-        }
+    # TODO: Handle additional Watch-Directory params, use param splattering?
+
+    & "C:\tools\scripts\Watch-Directory.ps1" -Path "C:\src" -Destination "C:\worker" -ExcludeFiles "Web.config"
+
     } | ForEach-Object {
         Write-Host ("### Started '$($_.Name)'.")
     }

--- a/windows/tests/9.3.x/docker-compose-xconnect-worker.yml
+++ b/windows/tests/9.3.x/docker-compose-xconnect-worker.yml
@@ -1,0 +1,100 @@
+version: '2.4'
+
+services:
+
+  sql:
+    image: ${REGISTRY}sitecore-xp-sqldev:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
+    volumes:
+      - .\data\sql:C:\Data
+    mem_limit: 2GB
+    ports:
+      - "44010:1433"
+    environment:
+      SA_PASSWORD: ${SQL_SA_PASSWORD}
+      ACCEPT_EULA: "Y"
+
+  solr:
+    image: ${REGISTRY}sitecore-xp-solr:${SITECORE_VERSION}-nanoserver-${NANOSERVER_VERSION}
+    volumes:
+      - .\data\solr:C:\Data
+    mem_limit: 1GB
+    ports:
+      - "44011:8983"
+
+  xconnect:
+    image: ${REGISTRY}sitecore-xp-xconnect:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
+    volumes:
+      - .\data\xconnect:C:\inetpub\wwwroot\App_Data\logs
+    entrypoint: powershell.exe -NoLogo -NoProfile -File C:\\tools\\entrypoints\\iis\\Development.ps1
+    mem_limit: 1GB
+    environment:
+      SITECORE_LICENSE: ${SITECORE_LICENSE}
+      SITECORE_SITECORE:XCONNECT:COLLECTIONSEARCH:SERVICES:SOLR.SOLRREADERSETTINGS:OPTIONS:REQUIREHTTPS: 'false'
+      SITECORE_SITECORE:XCONNECT:SEARCHINDEXER:SERVICES:SOLR.SOLRWRITERSETTINGS:OPTIONS:REQUIREHTTPS: 'false'
+      SITECORE_CONNECTIONSTRINGS_MESSAGING: Data Source=sql;Database=Sitecore.Messaging;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_PROCESSING.ENGINE.STORAGE: Data Source=sql;Database=Sitecore.ProcessingEngineStorage;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_REPORTING: Data Source=sql;Database=Sitecore.Reporting;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_XDB.MARKETINGAUTOMATION: Data Source=sql;Database=Sitecore.MarketingAutomation;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_XDB.PROCESSING.POOLS: Data Source=sql;Database=Sitecore.Processing.Pools;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_XDB.REFERENCEDATA: Data Source=sql;Database=Sitecore.ReferenceData;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_COLLECTION: Data Source=sql;Database=Sitecore.Xdb.Collection.ShardMapManager;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_SOLRCORE: http://solr:8983/solr/sitecore_xdb
+    depends_on:
+      - sql
+      - solr
+
+  xconnect-automationengine:
+    image: ${REGISTRY}sitecore-xp-xconnect-automationengine:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
+    volumes:
+      - .\data\xconnect-automationengine:C:\worker\App_Data\logs
+    mem_limit: 500MB
+    entrypoint: powershell.exe -NoLogo -NoProfile -File C:\\tools\\entrypoints\\worker\\Development.ps1
+
+    environment:
+      SITECORE_LICENSE: ${SITECORE_LICENSE}
+      SITECORE_CONNECTIONSTRINGS_XCONNECT.COLLECTION: http://xconnect
+      SITECORE_CONNECTIONSTRINGS_XDB.MARKETINGAUTOMATION: Data Source=sql;Database=Sitecore.MarketingAutomation;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_XDB.REFERENCEDATA: Data Source=sql;Database=Sitecore.ReferenceData;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_MESSAGING: Data Source=sql;Database=Sitecore.Messaging;User ID=sa;Password=${SQL_SA_PASSWORD}
+    depends_on:
+      - sql
+      - xconnect
+
+  xconnect-indexworker:
+    image: ${REGISTRY}sitecore-xp-xconnect-indexworker:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
+    volumes:
+      - .\data\xconnect-indexworker:C:\worker\App_Data\logs
+    entrypoint: powershell.exe -NoLogo -NoProfile -File C:\\tools\\entrypoints\\worker\\Development.ps1
+    mem_limit: 500MB
+    environment:
+      SITECORE_LICENSE: ${SITECORE_LICENSE}
+      SITECORE_CONNECTIONSTRINGS_COLLECTION: Data Source=sql;Initial Catalog=Sitecore.Xdb.Collection.ShardMapManager;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_SOLRCORE: http://solr:8983/solr/sitecore_xdb
+      SITECORE_SITECORE:XCONNECT:SEARCHINDEXER:SERVICES:SOLR.SOLRREADERSETTINGS:OPTIONS:REQUIREHTTPS: 'false'
+      SITECORE_SITECORE:XCONNECT:SEARCHINDEXER:SERVICES:SOLR.SOLRWRITERSETTINGS:OPTIONS:REQUIREHTTPS: 'false'
+    depends_on:
+      - sql
+      - solr
+
+  xconnect-processingengine:
+    image: ${REGISTRY}sitecore-xp-xconnect-processingengine:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
+    volumes:
+      - .\data\xconnect-processingengine:C:\worker\App_Data\logs
+    entrypoint: powershell.exe -NoLogo -NoProfile -File C:\\tools\\entrypoints\\worker\\Development.ps1
+    mem_limit: 500MB
+    restart: unless-stopped
+    environment:
+      SITECORE_LICENSE: ${SITECORE_LICENSE}
+      SITECORE_CONNECTIONSTRINGS_PROCESSING.ENGINE.STORAGE: Data Source=sql;Database=Sitecore.Processing.Engine.Storage;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_PROCESSING.ENGINE.TASKS: Data Source=sql;Database=Sitecore.Processing.Engine.Tasks;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_PROCESSING.WEBAPI.BLOB: http://xconnect
+      SITECORE_CONNECTIONSTRINGS_PROCESSING.WEBAPI.TABLE: http://xconnect
+      SITECORE_CONNECTIONSTRINGS_XCONNECT.COLLECTION: http://xconnect
+      SITECORE_CONNECTIONSTRINGS_XCONNECT.CONFIGURATION: http://xconnect
+      SITECORE_CONNECTIONSTRINGS_XCONNECT.SEARCH: http://xconnect
+      SITECORE_CONNECTIONSTRINGS_MESSAGING: Data Source=sql;Database=Sitecore.Messaging;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_CONNECTIONSTRINGS_REPORTING: Data Source=sql;Database=Sitecore.Reporting;User ID=sa;Password=${SQL_SA_PASSWORD}
+      SITECORE_SETTINGS:SERILOG:MINIMUMLEVEL:DEFAULT: Information
+    depends_on:
+      - sql
+      - xconnect


### PR DESCRIPTION
Added a test file for xConnect-only (and dependencies) roles.
