### PR TITLE
Standardize the time output.

### DIFF
--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -9,8 +9,9 @@ $ErrorActionPreference = "STOP"
 
 Import-Module WebAdministration
 
-function Wait-WebItemState
-{
+$timeFormat = "HH:mm:ss:fff"
+
+function Wait-WebItemState {
     param(
         [ValidateNotNullOrEmpty()]
         [string]$IISPath
@@ -19,34 +20,25 @@ function Wait-WebItemState
         [string]$State
     )
 
-    while ($true)
-    {
-        Write-Host "### Waiting on item '$IISPath' state to be '$State'..."
+    while ($true) {
+        Write-Host "$(Get-Date -Format $timeFormat): Waiting on item '$IISPath' state to be '$State'..."
 
-        try
-        {
+        try {
             $item = Get-Item -Path $IISPath
 
-            if ($null -ne $item -and $item.State -ne $State)
-            {
-                if ($State -eq "Started")
-                {
+            if ($null -ne $item -and $item.State -ne $State) {
+                if ($State -eq "Started") {
                     $item = Start-WebItem -PSPath $IISPath -Passthru -ErrorAction "SilentlyContinue"
-                }
-                elseif ($State -eq "Stopped")
-                {
+                } elseif ($State -eq "Stopped") {
                     $item = Stop-WebItem -PSPath $IISPath -Passthru -ErrorAction "SilentlyContinue"
                 }
             }
-        }
-        catch
-        {
+        } catch {
             $item = $null
         }
 
-        if ($null -ne $item -and $item.State -eq $State)
-        {
-            Write-Host "### Waiting on item '$IISPath' completed."
+        if ($null -ne $item -and $item.State -eq $State) {
+            Write-Host "$(Get-Date -Format $timeFormat): Waiting on item '$IISPath' completed."
 
             break
         }
@@ -56,24 +48,20 @@ function Wait-WebItemState
 }
 
 # print start message
-Write-Host ("### Sitecore Development ENTRYPOINT, starting...")
+Write-Host "$(Get-Date -Format $timeFormat): Sitecore Development ENTRYPOINT, starting..."
 
 # wait for w3wp to stop
-while ($true)
-{
+while ($true) {
     $processName = "w3wp"
 
-    Write-Host "### Waiting for process '$processName' to stop..."
+    Write-Host "$(Get-Date -Format $timeFormat): Waiting for process '$processName' to stop..."
 
     $running = [array](Get-Process -Name $processName -ErrorAction "SilentlyContinue").Length -gt 0
 
-    if ($running)
-    {
+    if ($running) {
         Stop-Process -Name $processName -Force -ErrorAction "SilentlyContinue"
-    }
-    else
-    {
-        Write-Host "### Process '$processName' stopped..."
+    } else {
+        Write-Host "$(Get-Date -Format $timeFormat): Process '$processName' stopped..."
 
         break;
     }
@@ -87,27 +75,22 @@ Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Stopped"
 # check to see if we should start the msvsmon.exe
 $useVsDebugger = (Test-Path -Path "C:\remote_debugger\x64\msvsmon.exe" -PathType "Leaf") -eq $true
 
-if ($useVsDebugger)
-{
+if ($useVsDebugger) {
     # start msvsmon.exe in background
     & "C:\remote_debugger\x64\msvsmon.exe" /noauth /anyuser /silent /nostatus /noclrwarn /nosecuritywarn /nofirewallwarn /nowowwarn /timeout:2147483646
 
-    Write-Host ("### Started 'msvsmon.exe'.")
-}
-else
-{
-    Write-Host ("### Skipping start of 'msvsmon.exe', to enable you should mount the Visual Studio Remote Debugger directory into 'C:\remote_debugger'.")
+    Write-Host "$(Get-Date -Format $timeFormat): Started 'msvsmon.exe'."
+} else {
+    Write-Host "$(Get-Date -Format $timeFormat): Skipping start of 'msvsmon.exe', to enable you should mount the Visual Studio Remote Debugger directory into 'C:\remote_debugger'."
 }
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
 $useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
-if ($useWatchDirectory)
-{
+if ($useWatchDirectory) {
     # setup default parameters if none is supplied
-    if ($null -eq $WatchDirectoryParameters)
-    {
+    if ($null -eq $WatchDirectoryParameters) {
         $WatchDirectoryParameters = @{ Path = "C:\src"; Destination = "C:\inetpub\wwwroot"; }
     }
 
@@ -115,12 +98,10 @@ if ($useWatchDirectory)
     Start-Job -Name $watchDirectoryJobName -ArgumentList $WatchDirectoryParameters -ScriptBlock {
         param([hashtable]$params)
 
-        try
-        {
+        try {
             & "C:\tools\scripts\Watch-Directory.ps1" @params
         }
-        finally
-        {
+        finally {
             Get-Process -Name "filebeat" | Stop-Process -Force
         }
     } | Out-Null
@@ -131,8 +112,7 @@ if ($useWatchDirectory)
     Get-Job -Name $watchDirectoryJobName | ForEach-Object {
         $job = $_
 
-        if ($job.State -ne "Running")
-        {
+        if ($job.State -ne "Running") {
             # writes output stream
             Receive-Job $job
 
@@ -140,44 +120,37 @@ if ($useWatchDirectory)
             exit 1
         }
 
-        Write-Host "### Job '$($job.Name)' started..."
+        Write-Host "$(Get-Date -Format $timeFormat): Job '$($job.Name)' started..."
     }
-}
-else
-{
-    Write-Host ("### Skipping start of '$watchDirectoryJobName', to enable you should mount a directory into 'C:\src'.")
+} else {
+    Write-Host "$(Get-Date -Format $timeFormat): Skipping start of '$watchDirectoryJobName', to enable you should mount a directory into 'C:\src'."
 }
 
 # inject Sitecore config files
-if (Test-Path -Path "C:\inetpub\wwwroot\App_Config\Include" -PathType "Container")
-{
+if (Test-Path -Path "C:\inetpub\wwwroot\App_Config\Include" -PathType "Container") {
     Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
 }
 
 # start ServiceMonitor.exe in background, kill foreground process if it fails
 Start-Job -Name "ServiceMonitor.exe" -ScriptBlock {
-    try
-    {
+    try {
         & "C:\ServiceMonitor.exe" "w3svc"
     }
-    finally
-    {
+    finally {
         Get-Process -Name "filebeat" | Stop-Process -Force
     }
 } | Out-Null
 
 # wait for the ServiceMonitor.exe process is running
-while ($true)
-{
+while ($true) {
     $processName = "ServiceMonitor"
 
-    Write-Host "### Waiting for process '$processName' to start..."
+    Write-Host "$(Get-Date -Format $timeFormat): Waiting for process '$processName' to start..."
 
     $running = [array](Get-Process -Name $processName -ErrorAction "SilentlyContinue").Length -eq 1
 
-    if ($running)
-    {
-        Write-Host "### Process '$processName' started..."
+    if ($running) {
+        Write-Host "$(Get-Date -Format $timeFormat): Process '$processName' started..."
 
         break;
     }
@@ -189,7 +162,7 @@ while ($true)
 Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Started"
 
 # print ready message
-Write-Host ("### Sitecore ready!")
+Write-Host "$(Get-Date -Format $timeFormat): Sitecore ready!"
 
 # start filebeat.exe in foreground
 & "C:\tools\bin\filebeat\filebeat.exe" -c (Join-Path $PSScriptRoot "\filebeat.yml")

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -11,7 +11,8 @@ Import-Module WebAdministration
 
 $timeFormat = "HH:mm:ss:fff"
 
-function Wait-WebItemState {
+function Wait-WebItemState
+{
     param(
         [ValidateNotNullOrEmpty()]
         [string]$IISPath
@@ -20,24 +21,33 @@ function Wait-WebItemState {
         [string]$State
     )
 
-    while ($true) {
+    while ($true)
+    {
         Write-Host "$(Get-Date -Format $timeFormat): Waiting on item '$IISPath' state to be '$State'..."
 
-        try {
+        try
+        {
             $item = Get-Item -Path $IISPath
 
-            if ($null -ne $item -and $item.State -ne $State) {
-                if ($State -eq "Started") {
+            if ($null -ne $item -and $item.State -ne $State)
+            {
+                if ($State -eq "Started")
+                {
                     $item = Start-WebItem -PSPath $IISPath -Passthru -ErrorAction "SilentlyContinue"
-                } elseif ($State -eq "Stopped") {
+                }
+                elseif ($State -eq "Stopped")
+                {
                     $item = Stop-WebItem -PSPath $IISPath -Passthru -ErrorAction "SilentlyContinue"
                 }
             }
-        } catch {
+        }
+        catch
+        {
             $item = $null
         }
 
-        if ($null -ne $item -and $item.State -eq $State) {
+        if ($null -ne $item -and $item.State -eq $State)
+        {
             Write-Host "$(Get-Date -Format $timeFormat): Waiting on item '$IISPath' completed."
 
             break
@@ -51,16 +61,20 @@ function Wait-WebItemState {
 Write-Host "$(Get-Date -Format $timeFormat): Sitecore Development ENTRYPOINT, starting..."
 
 # wait for w3wp to stop
-while ($true) {
+while ($true)
+{
     $processName = "w3wp"
 
     Write-Host "$(Get-Date -Format $timeFormat): Waiting for process '$processName' to stop..."
 
     $running = [array](Get-Process -Name $processName -ErrorAction "SilentlyContinue").Length -gt 0
 
-    if ($running) {
+    if ($running)
+    {
         Stop-Process -Name $processName -Force -ErrorAction "SilentlyContinue"
-    } else {
+    }
+    else
+    {
         Write-Host "$(Get-Date -Format $timeFormat): Process '$processName' stopped..."
 
         break;
@@ -75,12 +89,15 @@ Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Stopped"
 # check to see if we should start the msvsmon.exe
 $useVsDebugger = (Test-Path -Path "C:\remote_debugger\x64\msvsmon.exe" -PathType "Leaf") -eq $true
 
-if ($useVsDebugger) {
+if ($useVsDebugger)
+{
     # start msvsmon.exe in background
     & "C:\remote_debugger\x64\msvsmon.exe" /noauth /anyuser /silent /nostatus /noclrwarn /nosecuritywarn /nofirewallwarn /nowowwarn /timeout:2147483646
 
     Write-Host "$(Get-Date -Format $timeFormat): Started 'msvsmon.exe'."
-} else {
+}
+else
+{
     Write-Host "$(Get-Date -Format $timeFormat): Skipping start of 'msvsmon.exe', to enable you should mount the Visual Studio Remote Debugger directory into 'C:\remote_debugger'."
 }
 
@@ -88,9 +105,11 @@ if ($useVsDebugger) {
 $watchDirectoryJobName = "Watch-Directory.ps1"
 $useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
-if ($useWatchDirectory) {
+if ($useWatchDirectory)
+{
     # setup default parameters if none is supplied
-    if ($null -eq $WatchDirectoryParameters) {
+    if ($null -eq $WatchDirectoryParameters)
+    {
         $WatchDirectoryParameters = @{ Path = "C:\src"; Destination = "C:\inetpub\wwwroot"; }
     }
 
@@ -98,10 +117,12 @@ if ($useWatchDirectory) {
     Start-Job -Name $watchDirectoryJobName -ArgumentList $WatchDirectoryParameters -ScriptBlock {
         param([hashtable]$params)
 
-        try {
+        try
+        {
             & "C:\tools\scripts\Watch-Directory.ps1" @params
         }
-        finally {
+        finally
+        {
             Get-Process -Name "filebeat" | Stop-Process -Force
         }
     } | Out-Null
@@ -112,7 +133,8 @@ if ($useWatchDirectory) {
     Get-Job -Name $watchDirectoryJobName | ForEach-Object {
         $job = $_
 
-        if ($job.State -ne "Running") {
+        if ($job.State -ne "Running")
+        {
             # writes output stream
             Receive-Job $job
 
@@ -122,34 +144,41 @@ if ($useWatchDirectory) {
 
         Write-Host "$(Get-Date -Format $timeFormat): Job '$($job.Name)' started..."
     }
-} else {
+}
+else
+{
     Write-Host "$(Get-Date -Format $timeFormat): Skipping start of '$watchDirectoryJobName', to enable you should mount a directory into 'C:\src'."
 }
 
 # inject Sitecore config files
-if (Test-Path -Path "C:\inetpub\wwwroot\App_Config\Include" -PathType "Container") {
+if (Test-Path -Path "C:\inetpub\wwwroot\App_Config\Include" -PathType "Container")
+{
     Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
 }
 
 # start ServiceMonitor.exe in background, kill foreground process if it fails
 Start-Job -Name "ServiceMonitor.exe" -ScriptBlock {
-    try {
+    try
+    {
         & "C:\ServiceMonitor.exe" "w3svc"
     }
-    finally {
+    finally
+    {
         Get-Process -Name "filebeat" | Stop-Process -Force
     }
 } | Out-Null
 
 # wait for the ServiceMonitor.exe process is running
-while ($true) {
+while ($true)
+{
     $processName = "ServiceMonitor"
 
     Write-Host "$(Get-Date -Format $timeFormat): Waiting for process '$processName' to start..."
 
     $running = [array](Get-Process -Name $processName -ErrorAction "SilentlyContinue").Length -eq 1
 
-    if ($running) {
+    if ($running)
+    {
         Write-Host "$(Get-Date -Format $timeFormat): Process '$processName' started..."
 
         break;

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
@@ -3,6 +3,8 @@ $ErrorActionPreference = "STOP"
 
 Import-Module WebAdministration
 
+$timeFormat = "HH:mm:ss:fff"
+
 function Wait-WebItemState
 {
     param(
@@ -15,7 +17,7 @@ function Wait-WebItemState
 
     while ($true)
     {
-        Write-Host "### Waiting on item '$IISPath' state to be '$State'..."
+        Write-Host "$(Get-Date -Format $timeFormat): Waiting on item '$IISPath' state to be '$State'..."
 
         try
         {
@@ -40,7 +42,7 @@ function Wait-WebItemState
 
         if ($null -ne $item -and $item.State -eq $State)
         {
-            Write-Host "### Waiting on item '$IISPath' completed."
+            Write-Host "$(Get-Date -Format $timeFormat): Waiting on item '$IISPath' completed."
 
             break
         }
@@ -50,14 +52,14 @@ function Wait-WebItemState
 }
 
 # print start message
-Write-Host ("### Sitecore Production ENTRYPOINT, starting...")
+Write-Host ("$(Get-Date -Format $timeFormat): Sitecore Production ENTRYPOINT, starting...")
 
 # wait for w3wp to stop
 while ($true)
 {
     $processName = "w3wp"
 
-    Write-Host "### Waiting for process '$processName' to stop..."
+    Write-Host "$(Get-Date -Format $timeFormat): Waiting for process '$processName' to stop..."
 
     $running = [array](Get-Process -Name $processName -ErrorAction "SilentlyContinue").Length -gt 0
 
@@ -67,7 +69,7 @@ while ($true)
     }
     else
     {
-        Write-Host "### Process '$processName' stopped..."
+        Write-Host "$(Get-Date -Format $timeFormat): Process '$processName' stopped..."
 
         break;
     }
@@ -100,13 +102,13 @@ while ($true)
 {
     $processName = "ServiceMonitor"
 
-    Write-Host "### Waiting for process '$processName' to start..."
+    Write-Host "$(Get-Date -Format $timeFormat): Waiting for process '$processName' to start..."
 
     $running = [array](Get-Process -Name $processName -ErrorAction "SilentlyContinue").Length -eq 1
 
     if ($running)
     {
-        Write-Host "### Process '$processName' started..."
+        Write-Host "$(Get-Date -Format $timeFormat): Process '$processName' started..."
 
         break;
     }
@@ -118,7 +120,7 @@ while ($true)
 Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Started"
 
 # print ready message
-Write-Host ("### Sitecore ready!")
+Write-Host ("$(Get-Date -Format $timeFormat): Sitecore ready!")
 
 # start filebeat.exe in foreground
 & "C:\tools\bin\filebeat\filebeat.exe" -c (Join-Path $PSScriptRoot "\filebeat.yml")

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Production.ps1
@@ -80,7 +80,8 @@ while ($true)
 # wait for application pool to stop
 Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Stopped"
 
-if (Test-Path -Path "C:\inetput\wwwroot\App_Config\Include") {
+if (Test-Path -Path "C:\inetput\wwwroot\App_Config\Include")
+{
     # inject Sitecore config files
     Copy-Item -Path (Join-Path $PSScriptRoot "\*.config") -Destination "C:\inetpub\wwwroot\App_Config\Include"
 }

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
@@ -7,8 +7,10 @@ param(
 # setup
 $ErrorActionPreference = "STOP"
 
+$timeFormat = "HH:mm:ss:fff"
+
 # print start message
-Write-Host ("### Sitecore Development ENTRYPOINT, starting...")
+Write-Host ("$(Get-Date -Format $timeFormat): Sitecore Development ENTRYPOINT, starting...")
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
@@ -45,12 +47,12 @@ if ($useWatchDirectory)
             exit 1
         }
 
-        Write-Host "### Job '$($job.Name)' started..."
+        Write-Host "$(Get-Date -Format $timeFormat): Job '$($job.Name)' started..."
     }
 }
 else
 {
-    Write-Host ("### Skipping start of '$watchDirectoryJobName', to enable you should mount a directory into 'C:\src'.")
+    Write-Host ("$(Get-Date -Format $timeFormat): Skipping start of '$watchDirectoryJobName', to enable you should mount a directory into 'C:\src'.")
 }
 
 & "C:\\worker\\$($env:SC_ROLE_EXE)"


### PR DESCRIPTION
Changed the output messages to no longer use '###'. Instead now it shows the time in a common format. Also updated Development.ps1 to include a switch to override the watcher. I don't see the need for this script to have many options.