### PR TITLE
fixed issue with some bases image not being included

### DIFF
--- a/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
+++ b/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
@@ -389,7 +389,7 @@ function Initialize-BuildSpecifications
             Write-Verbose ("Tag '{0}' excluded as it is deprecated and the DeprecatedTagsBehavior parameter is '{1}'." -f $spec.Tag, $DeprecatedTagsBehavior)
         }
 
-        if ($spec.Include -eq $true -and $spec.Experimental-eq $true -and $ExperimentalTagBehavior -eq "Skip")
+        if ($spec.Include -eq $true -and $spec.Experimental -eq $true -and $ExperimentalTagBehavior -eq "Skip")
         {
             $spec.Include = $false
 
@@ -403,10 +403,10 @@ function Initialize-BuildSpecifications
         $Specifications | Where-Object { $_.Include -eq $true } | ForEach-Object {
             $spec = $_
 
-            # Recursively iterate bases, excluding external ones, and re-include them
+            # Recursively iterate base images and re-include them if needed
             $baseSpecs = $Specifications | Where-Object { $spec.Base -contains $_.Tag }
 
-            while ($null -ne $baseSpecs)
+            while ($null -ne $baseSpecs -and $baseSpecs.Length -gt 0)
             {
                 $baseSpecs | ForEach-Object {
                     $baseSpec = $_
@@ -419,7 +419,7 @@ function Initialize-BuildSpecifications
                     }
                 }
 
-                $baseSpecs = $Specifications | Where-Object { $baseSpecs.Base -contains $_.Tag } | Select-Object -First 1
+                $baseSpecs = $Specifications | Where-Object { $baseSpecs.Base -contains $_.Tag }
             }
         }
     }


### PR DESCRIPTION
fixed issue with some base images not automaticlly being included in the tags to build.

Before:

```
sitecore-assets:9.3.0-nanoserver-1809                                     True      False        0 {mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/nanoserver:1809}
sitecore-xm-spe-cm:9.3.0-windowsservercore-ltsc2019                       True      False       17 {sitecore-assets:9.3.0-nanoserver-1809, sitecore-xm-cm:9.3.0-windowsservercore-ltsc2019}
sitecore-xm-sxa-cm:9.3.0-windowsservercore-ltsc2019                       True      False       19 {sitecore-assets:9.3.0-nanoserver-1809, sitecore-xm-spe-cm:9.3.0-windowsservercore-ltsc2019}
```

> Notice that the xm-cm which is a dependency to xm-sxa-cm is missing.

After:

```
sitecore-assets:9.3.0-nanoserver-1809                                     True      False        0 {mcr.microsoft.com/windows/servercore:ltsc2019, mcr.microsoft.com/windows/nanoserver:1809}
sitecore-xm-cm:9.3.0-windowsservercore-ltsc2019                           True      False       14 {sitecore-assets:9.3.0-nanoserver-1809, mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019}
sitecore-xm-spe-cm:9.3.0-windowsservercore-ltsc2019                       True      False       17 {sitecore-assets:9.3.0-nanoserver-1809, sitecore-xm-cm:9.3.0-windowsservercore-ltsc2019}
sitecore-xm-sxa-cm:9.3.0-windowsservercore-ltsc2019                       True      False       19 {sitecore-assets:9.3.0-nanoserver-1809, sitecore-xm-spe-cm:9.3.0-windowsservercore-ltsc2019}
```