### PR TITLE
Fixing `Build.ps1`

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -29,6 +29,11 @@ param(
 $ErrorActionPreference = "STOP"
 $ProgressPreference = "SilentlyContinue"
 
+# optional, default value is the latest Sitecore version on latest LTSC version
+# of Windows. Set to for example "*" for build everything or "*:9.1.1*1903", "*:9.2.0*1903" to
+# only build 9.1.1 and 9.2.0 on Windows 1903.
+$tags = "*"
+
 # load module
 Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -Force
 
@@ -36,6 +41,7 @@ Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -Force
 SitecoreImageBuilder\Invoke-PackageRestore `
     -Path (Join-Path $PSScriptRoot "\windows") `
     -Destination $InstallSourcePath `
+    -Tags $tags `
     -SitecoreUsername $SitecoreUsername `
     -SitecorePassword $SitecorePassword `
     -WhatIf:$WhatIfPreference
@@ -44,5 +50,6 @@ SitecoreImageBuilder\Invoke-PackageRestore `
 SitecoreImageBuilder\Invoke-Build `
     -Path (Join-Path $PSScriptRoot "\windows") `
     -InstallSourcePath $InstallSourcePath `
+    -Tags $tags `
     -Registry $Registry `
     -WhatIf:$WhatIfPreference


### PR DESCRIPTION
adding back the `Tags` parameter to the Invoke-Build call in Build.ps1. Without it, the call does nothing. The `Tags` parameter is in your example script in the README, just not in the actual `Build.ps1` script in the repo.