### PR TITLE
Provide a low complexity way for developers to filter out build options

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -3,27 +3,36 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "RegistryPassword")]
 
 param(
-    [Parameter(Mandatory = $false)]
+    [Parameter()]
     [ValidateNotNullOrEmpty()]
-    [string]$InstallSourcePath = (Join-Path $PSScriptRoot "\packages")
-    ,
+    [string]$InstallSourcePath = (Join-Path $PSScriptRoot "\packages"),
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
-    [string]$SitecoreUsername
-    ,
+    [string]$SitecoreUsername,
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
-    [string]$SitecorePassword
-    ,
-    [Parameter(Mandatory = $false)]
-    [string]$Registry = ""
-    ,
-    [Parameter(Mandatory = $false)]
-    [string]$RegistryUserName = ""
-    ,
-    [Parameter(Mandatory = $false)]
-    [string]$RegistryPassword = ""
-
+    [string]$SitecorePassword,
+    [Parameter()]
+    [string]$Registry = "",
+    [Parameter()]
+    [string]$RegistryUserName = "",
+    [Parameter()]
+    [string]$RegistryPassword = "",
+    [Parameter()]
+    [ValidateSet("9.3.0","9.2.0","9.1.1", "9.0.2")]
+    [string[]]$SitecoreVersion = @("9.3.0"),
+    [ValidateSet("xm","xp", "xc")]
+    [string[]]$Topology = @("xm","xp","xc"),
+    [ValidateSet("1909","1903","1809")]
+    [string[]]$WindowsVersion = @("1909"),
+    [Parameter()]
+    [switch]$IncludeSpe,
+    [Parameter()]
+    [switch]$IncludeSxa,
+    [Parameter()]
+    [switch]$IncludeJss,
+    [Parameter()]
+    [switch]$RebuildExisting
 )
 
 $ErrorActionPreference = "STOP"
@@ -32,12 +41,148 @@ $ProgressPreference = "SilentlyContinue"
 # load module
 Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -Force
 
+$tags = [System.Collections.ArrayList]@()
+# Sitecore roles
+$windowsLookup = @{
+    "1909" = "1909"
+    "1903" = "1903"
+    "1809" = "ltsc2019"
+    "1803" = "1803"
+}
+foreach($wv in $WindowsVersion) {
+    $tags.Add("mssql-developer:2017-windowsservercore-$($windowsLookup[$wv])") > $null
+    $tags.Add("sitecore-certificates:latest-nanoserver-$($wv)") > $null
+    $tags.Add("sitecore-openjdk:8-nanoserver-$($wv)") > $null
+    $tags.Add("sitecore-redis:3.0.504-windowsservercore-$($windowsLookup[$wv])") > $null
+
+    foreach($scv in $SitecoreVersion) {
+        $tags.Add("sitecore-assets:$($scv)-nanoserver-$($wv)") > $null
+        if([Version]$scv -ge [Version]"9.3.0" -and [int]$wv -gt 1809) {
+            $tags.Add("sitecore-ps:$($scv)-nanoserver-$($wv)") > $null
+        }
+
+        if($Topology -contains "xm") {
+            $tags.Add("sitecore-xm-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xm-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xm-solr:$($scv)-nanoserver-$($wv)") > $null
+            $tags.Add("sitecore-xm-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        }
+
+        if($Topology -contains "xp") {
+            $tags.Add("sitecore-xp-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xp-identity:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xp-solr:$($scv)-nanoserver-$($wv)") > $null
+            $tags.Add("sitecore-xp-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xp-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xp-xconnect:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xp-xconnect-automationengine:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xp-xconnect-indexworker:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xp-xconnect-processingengine:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        }
+
+        if($Topology -contains "xc") {
+            $tags.Add("sitecore-xc-bizfx:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-engine-authoring:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-engine-minions:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-engine-ops:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-engine-shops:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-identity:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-solr:$($scv)-nanoserver-$($wv)") > $null
+            $tags.Add("sitecore-xc-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-xconnect-automationengine:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            $tags.Add("sitecore-xc-xconnect-indexworker:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        }
+
+        if($IncludeSpe.IsPresent) {
+            if($Topology -contains "xm") {
+                $tags.Add("sitecore-xm-spe-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xm-spe-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+
+            if($Topology -contains "xp") {
+                $tags.Add("sitecore-xp-spe-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-spe-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+
+            if($Topology -contains "xc") {
+                $tags.Add("sitecore-xc-spe-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xc-spe-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xc-spe-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+        }
+
+        if($IncludeSxa.IsPresent) {
+            if($Topology -contains "xm") {
+                $tags.Add("sitecore-xm-sxa-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xm-sxa-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xm-sxa-solr:$($scv)-nanoserver-$($wv)") > $null
+                $tags.Add("sitecore-xm-sxa-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+
+            if($Topology -contains "xp") {
+                $tags.Add("sitecore-xp-sxa-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-sxa-ps-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-sxa-ps-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-sxa-ps-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-sxa-ps-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-sxa-solr:$($scv)-nanoserver-$($wv)") > $null
+                $tags.Add("sitecore-xp-sxa-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-sxa-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+
+            if($Topology -contains "xc") {
+                $tags.Add("sitecore-xc-sxa-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xc-sxa-solr:$($scv)-nanoserver-$($wv)") > $null
+                $tags.Add("sitecore-xc-sxa-storefront-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xc-sxa-storefront-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xc-sxa-storefront-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xc-sxa-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+        }
+
+        if($IncludeJss.IsPresent) {
+            if($Topology -contains "xm") {
+                $tags.Add("sitecore-xm-jss-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xm-jss-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xm-jss-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+
+            if($Topology -contains "xp") {
+                $tags.Add("sitecore-xp-jss-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-jss-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+                $tags.Add("sitecore-xp-jss-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            }
+        }
+    }
+}
+
+if(!$RebuildExisting.IsPresent) {
+    Write-Host "Existing images will be excluded from the build."
+    $existingImages = docker images --format '{{.Repository}}:{{.Tag}}' --filter 'dangling=false'
+    foreach($existingImage in $existingImages) {
+        if($tags -contains $existingImage) {
+            $tags.Remove($existingImage)
+        }
+    }
+}
+
+if($tags) {
+    Write-Host "The following images will be built:"
+    $tags
+} else {
+    Write-Host "No images need to be built."
+    exit
+}
+
 # restore any missing packages
 SitecoreImageBuilder\Invoke-PackageRestore `
     -Path (Join-Path $PSScriptRoot "\windows") `
     -Destination $InstallSourcePath `
     -SitecoreUsername $SitecoreUsername `
     -SitecorePassword $SitecorePassword `
+    -Tags $tags `
     -WhatIf:$WhatIfPreference
 
 # start the build
@@ -45,4 +190,5 @@ SitecoreImageBuilder\Invoke-Build `
     -Path (Join-Path $PSScriptRoot "\windows") `
     -InstallSourcePath $InstallSourcePath `
     -Registry $Registry `
+    -Tags $tags `
     -WhatIf:$WhatIfPreference

--- a/Build.ps1
+++ b/Build.ps1
@@ -19,12 +19,12 @@ param(
     [Parameter()]
     [string]$RegistryPassword = "",
     [Parameter()]
-    [ValidateSet("9.3.0","9.2.0","9.1.1", "9.0.2")]
+    [ValidateSet("9.3.0", "9.2.0", "9.1.1", "9.0.2")]
     [string[]]$SitecoreVersion = @("9.3.0"),
-    [ValidateSet("xm","xp", "xc")]
-    [string[]]$Topology = @("xm","xp","xc"),
-    [ValidateSet("1909","1903","1809")]
-    [string[]]$WindowsVersion = @("1909"),
+    [ValidateSet("xm", "xp", "xc")]
+    [string[]]$Topology = @("xm", "xp", "xc"),
+    [ValidateSet("1909", "1903", "ltsc2019")]
+    [string[]]$WindowsVersion = @("ltsc2019"),
     [Parameter()]
     [switch]$IncludeSpe,
     [Parameter()]
@@ -42,136 +42,158 @@ $ProgressPreference = "SilentlyContinue"
 Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -Force
 
 $tags = [System.Collections.ArrayList]@()
-# Sitecore roles
-$windowsLookup = @{
-    "1909" = "1909"
-    "1903" = "1903"
-    "1809" = "ltsc2019"
-    "1803" = "1803"
+$windowsVersionMapping = @{
+    "1909"     = "1909"
+    "1903"     = "1903"
+    "ltsc2019" = "1809"
+    "1803"     = "1803"
 }
-foreach($wv in $WindowsVersion) {
-    $tags.Add("mssql-developer:2017-windowsservercore-$($windowsLookup[$wv])") > $null
-    $tags.Add("sitecore-certificates:latest-nanoserver-$($wv)") > $null
-    $tags.Add("sitecore-openjdk:8-nanoserver-$($wv)") > $null
-    $tags.Add("sitecore-redis:3.0.504-windowsservercore-$($windowsLookup[$wv])") > $null
+foreach ($wv in $WindowsVersion)
+{
+    $tags.Add("mssql-developer:2017-windowsservercore-$($wv)") > $null
+    $tags.Add("sitecore-certificates:latest-nanoserver-$($windowsVersionMapping[$wv])") > $null
+    $tags.Add("sitecore-openjdk:8-nanoserver-$($windowsVersionMapping[$wv])") > $null
+    $tags.Add("sitecore-redis:3.0.504-windowsservercore-$($wv)") > $null
 
-    foreach($scv in $SitecoreVersion) {
-        $tags.Add("sitecore-assets:$($scv)-nanoserver-$($wv)") > $null
-        if([Version]$scv -ge [Version]"9.3.0" -and [int]$wv -gt 1809) {
-            $tags.Add("sitecore-ps:$($scv)-nanoserver-$($wv)") > $null
+    foreach ($scv in $SitecoreVersion)
+    {
+        $tags.Add("sitecore-assets:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
+        if ([Version]$scv -ge [Version]"9.3.0" -and [int]$windowsVersionMapping[$wv] -gt 1809)
+        {
+            $tags.Add("sitecore-ps:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
         }
 
-        if($Topology -contains "xm") {
-            $tags.Add("sitecore-xm-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xm-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xm-solr:$($scv)-nanoserver-$($wv)") > $null
-            $tags.Add("sitecore-xm-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        if ($Topology -contains "xm")
+        {
+            $tags.Add("sitecore-xm-cd:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xm-cm:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xm-solr:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
+            $tags.Add("sitecore-xm-sqldev:$($scv)-windowsservercore-$($wv)") > $null
         }
 
-        if($Topology -contains "xp") {
-            $tags.Add("sitecore-xp-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xp-identity:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xp-solr:$($scv)-nanoserver-$($wv)") > $null
-            $tags.Add("sitecore-xp-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xp-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xp-xconnect:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xp-xconnect-automationengine:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xp-xconnect-indexworker:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xp-xconnect-processingengine:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        if ($Topology -contains "xp")
+        {
+            $tags.Add("sitecore-xp-cd:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xp-identity:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xp-solr:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
+            $tags.Add("sitecore-xp-standalone:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xp-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xp-xconnect:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xp-xconnect-automationengine:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xp-xconnect-indexworker:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xp-xconnect-processingengine:$($scv)-windowsservercore-$($wv)") > $null
         }
 
-        if($Topology -contains "xc") {
-            $tags.Add("sitecore-xc-bizfx:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-engine-authoring:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-engine-minions:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-engine-ops:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-engine-shops:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-identity:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-solr:$($scv)-nanoserver-$($wv)") > $null
-            $tags.Add("sitecore-xc-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-xconnect-automationengine:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            $tags.Add("sitecore-xc-xconnect-indexworker:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        if ($Topology -contains "xc")
+        {
+            $tags.Add("sitecore-xc-bizfx:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-cd:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-engine-authoring:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-engine-minions:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-engine-ops:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-engine-shops:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-identity:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-solr:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
+            $tags.Add("sitecore-xc-standalone:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-xconnect-automationengine:$($scv)-windowsservercore-$($wv)") > $null
+            $tags.Add("sitecore-xc-xconnect-indexworker:$($scv)-windowsservercore-$($wv)") > $null
         }
 
-        if($IncludeSpe.IsPresent) {
-            if($Topology -contains "xm") {
-                $tags.Add("sitecore-xm-spe-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xm-spe-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        if ($IncludeSpe.IsPresent)
+        {
+            if ($Topology -contains "xm")
+            {
+                $tags.Add("sitecore-xm-spe-cm:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xm-spe-sqldev:$($scv)-windowsservercore-$($wv)") > $null
             }
 
-            if($Topology -contains "xp") {
-                $tags.Add("sitecore-xp-spe-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-spe-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            if ($Topology -contains "xp")
+            {
+                $tags.Add("sitecore-xp-spe-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-spe-standalone:$($scv)-windowsservercore-$($wv)") > $null
             }
 
-            if($Topology -contains "xc") {
-                $tags.Add("sitecore-xc-spe-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xc-spe-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xc-spe-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            }
-        }
-
-        if($IncludeSxa.IsPresent) {
-            if($Topology -contains "xm") {
-                $tags.Add("sitecore-xm-sxa-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xm-sxa-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xm-sxa-solr:$($scv)-nanoserver-$($wv)") > $null
-                $tags.Add("sitecore-xm-sxa-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            }
-
-            if($Topology -contains "xp") {
-                $tags.Add("sitecore-xp-sxa-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-sxa-ps-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-sxa-ps-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-sxa-ps-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-sxa-ps-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-sxa-solr:$($scv)-nanoserver-$($wv)") > $null
-                $tags.Add("sitecore-xp-sxa-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-sxa-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-            }
-
-            if($Topology -contains "xc") {
-                $tags.Add("sitecore-xc-sxa-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xc-sxa-solr:$($scv)-nanoserver-$($wv)") > $null
-                $tags.Add("sitecore-xc-sxa-storefront-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xc-sxa-storefront-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xc-sxa-storefront-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xc-sxa-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            if ($Topology -contains "xc")
+            {
+                $tags.Add("sitecore-xc-spe-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xc-spe-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xc-spe-standalone:$($scv)-windowsservercore-$($wv)") > $null
             }
         }
 
-        if($IncludeJss.IsPresent) {
-            if($Topology -contains "xm") {
-                $tags.Add("sitecore-xm-jss-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xm-jss-cm:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xm-jss-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+        if ($IncludeSxa.IsPresent)
+        {
+            if ($Topology -contains "xm")
+            {
+                $tags.Add("sitecore-xm-sxa-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xm-sxa-cm:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xm-sxa-solr:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
+                $tags.Add("sitecore-xm-sxa-sqldev:$($scv)-windowsservercore-$($wv)") > $null
             }
 
-            if($Topology -contains "xp") {
-                $tags.Add("sitecore-xp-jss-cd:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-jss-sqldev:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
-                $tags.Add("sitecore-xp-jss-standalone:$($scv)-windowsservercore-$($windowsLookup[$wv])") > $null
+            if ($Topology -contains "xp")
+            {
+                $tags.Add("sitecore-xp-sxa-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-sxa-ps-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-sxa-ps-cm:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-sxa-ps-standalone:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-sxa-ps-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-sxa-solr:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
+                $tags.Add("sitecore-xp-sxa-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-sxa-standalone:$($scv)-windowsservercore-$($wv)") > $null
+            }
+
+            if ($Topology -contains "xc")
+            {
+                $tags.Add("sitecore-xc-sxa-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xc-sxa-solr:$($scv)-nanoserver-$($windowsVersionMapping[$wv])") > $null
+                $tags.Add("sitecore-xc-sxa-storefront-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xc-sxa-storefront-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xc-sxa-storefront-standalone:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xc-sxa-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+            }
+        }
+
+        if ($IncludeJss.IsPresent)
+        {
+            if ($Topology -contains "xm")
+            {
+                $tags.Add("sitecore-xm-jss-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xm-jss-cm:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xm-jss-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+            }
+
+            if ($Topology -contains "xp")
+            {
+                $tags.Add("sitecore-xp-jss-cd:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-jss-sqldev:$($scv)-windowsservercore-$($wv)") > $null
+                $tags.Add("sitecore-xp-jss-standalone:$($scv)-windowsservercore-$($wv)") > $null
             }
         }
     }
 }
 
-if(!$RebuildExisting.IsPresent) {
+if (!$RebuildExisting.IsPresent)
+{
     Write-Host "Existing images will be excluded from the build."
     $existingImages = docker images --format '{{.Repository}}:{{.Tag}}' --filter 'dangling=false'
-    foreach($existingImage in $existingImages) {
-        if($tags -contains $existingImage) {
+    foreach ($existingImage in $existingImages)
+    {
+        if ($tags -contains $existingImage)
+        {
             $tags.Remove($existingImage)
         }
     }
 }
 
-if($tags) {
+if ($tags)
+{
     Write-Host "The following images will be built:"
     $tags
-} else {
+}
+else
+{
     Write-Host "No images need to be built."
     exit
 }


### PR DESCRIPTION
Now you can use the following options to filter what is built.

```powershell
.\Build.ps1 -SitecoreUsername here@here.com -SitecorePassword abc123 -SitecoreVersion 9.3.0 -Topology xm -WindowsVersion 1809 -IncludeSpe -IncludeSxa -IncludeJss -RebuildExisting
```