### PR TITLE
Reversed behavior to avoid a breaking change.

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -31,8 +31,8 @@ param(
     [switch]$IncludeSxa,
     [Parameter()]
     [switch]$IncludeJss,
-    [Parameter()]
-    [switch]$RebuildExisting
+    [Parameter(HelpMessage="If the docker image is already built it should be skipped.")]
+    [switch]$SkipExistingImage
 )
 
 $ErrorActionPreference = "STOP"
@@ -174,7 +174,7 @@ foreach ($wv in $WindowsVersion)
     }
 }
 
-if (!$RebuildExisting.IsPresent)
+if ($SkipExistingImage.IsPresent)
 {
     Write-Host "Existing images will be excluded from the build."
     $existingImages = docker images --format '{{.Repository}}:{{.Tag}}' --filter 'dangling=false'


### PR DESCRIPTION
Now you have to explicitly specify that you want to skip building an existing image.

Thanks for the feedback @pbering .