### PR TITLE
Specifications improvements

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -31,7 +31,7 @@ param(
     [switch]$IncludeSxa,
     [Parameter()]
     [switch]$IncludeJss,
-    [Parameter(HelpMessage="If the docker image is already built it should be skipped.")]
+    [Parameter(HelpMessage = "If the docker image is already built it should be skipped.")]
     [switch]$SkipExistingImage,
     [Parameter()]
     [switch]$IncludeExperimental
@@ -56,12 +56,28 @@ $windowsVersionMapping = @{
     "ltsc2019" = "1809"
 }
 
-filter WindowsFilter { param([string]$Version) if($_ -like "*-windowsservercore-$($Version)" -or $_ -like "*-nanoserver-$($windowsVersionMapping[$Version])") { $_ } }
-filter SitecoreFilter { param([string]$Version) if($_ -like "*:$($Version)-windowsservercore-*" -or $_ -like "*:$($Version)-nanoserver-*") { $_ } }
+filter WindowsFilter
+{
+    param([string]$Version)
+    if ($_ -like "*-windowsservercore-$($Version)" -or $_ -like "*-nanoserver-$($windowsVersionMapping[$Version])")
+    {
+        $_
+    }
+}
+
+filter SitecoreFilter
+{
+    param([string]$Version)
+    if ($_ -like "*:$($Version)-windowsservercore-*" -or $_ -like "*:$($Version)-nanoserver-*")
+    {
+        $_
+    }
+}
 
 $availableSpecs = Get-BuildSpecifications -Path (Join-Path $PSScriptRoot "\windows")
 
-if(!$IncludeExperimental) {
+if (!$IncludeExperimental)
+{
     Write-Host "Excluding experimental images."
     $availableSpecs = $availableSpecs | Where-Object { !$_.Experimental }
 }
@@ -110,65 +126,65 @@ foreach ($wv in $WindowsVersion)
         $assetTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         $catchAllTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
 
-        if($Topology -contains "xm")
+        if ($Topology -contains "xm")
         {
             $xmTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         }
 
-        if($Topology -contains "xp")
+        if ($Topology -contains "xp")
         {
             $xpTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         }
 
-        if($Topology -contains "xc")
+        if ($Topology -contains "xc")
         {
             $xcTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         }
 
-        if($IncludeSpe)
+        if ($IncludeSpe)
         {
-            if($Topology -contains "xm")
+            if ($Topology -contains "xm")
             {
                 $xmSpeTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xp")
+            if ($Topology -contains "xp")
             {
                 $xpSpeTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xc")
+            if ($Topology -contains "xc")
             {
                 $xcSpeTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
         }
 
-        if($IncludeSxa)
+        if ($IncludeSxa)
         {
-            if($Topology -contains "xm")
+            if ($Topology -contains "xm")
             {
                 $xmSxaTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xp")
+            if ($Topology -contains "xp")
             {
                 $xpSxaTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xc")
+            if ($Topology -contains "xc")
             {
                 $xcSxaTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
         }
 
-        if($IncludeJss)
+        if ($IncludeJss)
         {
-            if($Topology -contains "xm")
+            if ($Topology -contains "xm")
             {
                 $xmJssTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xp")
+            if ($Topology -contains "xp")
             {
                 $xpJssTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
@@ -209,7 +225,7 @@ SitecoreImageBuilder\Invoke-PackageRestore `
     -SitecoreUsername $SitecoreUsername `
     -SitecorePassword $SitecorePassword `
     -Tags $tags `
-    -ExperimentalTagBehavior:(@{$true="Include";$false="Skip"}[$IncludeExperimental -eq $true]) `
+    -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
     -WhatIf:$WhatIfPreference
 
 # start the build
@@ -218,5 +234,5 @@ SitecoreImageBuilder\Invoke-Build `
     -InstallSourcePath $InstallSourcePath `
     -Registry $Registry `
     -Tags $tags `
-    -ExperimentalTagBehavior:(@{$true="Include";$false="Skip"}[$IncludeExperimental -eq $true]) `
+    -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
     -WhatIf:$WhatIfPreference

--- a/Build.ps1
+++ b/Build.ps1
@@ -176,7 +176,7 @@ foreach ($wv in $WindowsVersion)
     }
 }
 
-$tags = $tags | Select-Object -Unique
+$tags = [System.Collections.ArrayList]@($tags | Select-Object -Unique)
 
 if ($SkipExistingImage)
 {

--- a/Build.ps1
+++ b/Build.ps1
@@ -5,7 +5,7 @@
 param(
     [Parameter()]
     [ValidateNotNullOrEmpty()]
-    [string]$InstallSourcePath = (Join-Path $PSScriptRoot "\packages"),
+    [string]$InstallSourcePath,
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string]$SitecoreUsername,
@@ -35,6 +35,11 @@ param(
     [switch]$SkipExistingImage
 )
 
+if ([string]::IsNullOrEmpty($InstallSourcePath))
+{
+    $InstallSourcePath = (Join-Path -Path $PSScriptRoot -ChildPath "\packages")
+}
+
 $ErrorActionPreference = "STOP"
 $ProgressPreference = "SilentlyContinue"
 
@@ -42,11 +47,11 @@ $ProgressPreference = "SilentlyContinue"
 Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -RequiredVersion 1.0.0 -Force
 
 $tags = [System.Collections.ArrayList]@()
+
 $windowsVersionMapping = @{
     "1909"     = "1909"
     "1903"     = "1903"
     "ltsc2019" = "1809"
-    "1803"     = "1803"
 }
 foreach ($wv in $WindowsVersion)
 {

--- a/Build.ps1
+++ b/Build.ps1
@@ -56,9 +56,17 @@ $windowsVersionMapping = @{
 foreach ($wv in $WindowsVersion)
 {
     $tags.Add("mssql-developer:2017-windowsservercore-$($wv)") > $null
-    $tags.Add("sitecore-certificates:latest-nanoserver-$($windowsVersionMapping[$wv])") > $null
     $tags.Add("sitecore-openjdk:8-nanoserver-$($windowsVersionMapping[$wv])") > $null
-    $tags.Add("sitecore-redis:3.0.504-windowsservercore-$($wv)") > $null
+
+    if ($Topology -contains "xp" -or $Topology -contains "xc")
+    {
+        $tags.Add("sitecore-certificates:latest-nanoserver-$($windowsVersionMapping[$wv])") > $null
+    }
+
+    if ($Topology -contains "xc")
+    {
+        $tags.Add("sitecore-redis:3.0.504-windowsservercore-$($wv)") > $null
+    }
 
     foreach ($scv in $SitecoreVersion)
     {

--- a/modules/SitecoreImageBuilder/1.0.0/Private/Get-LatestSupportedVersionTags.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Private/Get-LatestSupportedVersionTags.ps1
@@ -1,6 +1,12 @@
 function Get-LatestSupportedVersionTags
 {
-    $latest = Get-LatestSupportedVersion
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [array]$Specs
+    )
+
+    $latest = Get-LatestSupportedVersion -Specs $Specs
 
     Write-Output ("*:{0}*{1}" -f $latest.Sitecore, $latest.WindowsServerCore)
     Write-Output ("*:{0}*{1}" -f $latest.Sitecore, $latest.NanoServer)

--- a/modules/SitecoreImageBuilder/1.0.0/Private/Initialize-BuildSpecifications.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Private/Initialize-BuildSpecifications.ps1
@@ -10,7 +10,7 @@ function Initialize-BuildSpecifications
         [string]$InstallSourcePath
         ,
         [Parameter(Mandatory = $false)]
-        [array]$Tags = (Get-LatestSupportedVersionTags)
+        [array]$Tags
         ,
         [Parameter(Mandatory = $false)]
         [ValidateSet("Include", "Skip")]
@@ -24,6 +24,11 @@ function Initialize-BuildSpecifications
         [ValidateSet("Include", "Skip")]
         [string]$ExperimentalTagBehavior = "Skip"
     )
+
+    if ($Tags -eq $null)
+    {
+        $Tags = Get-LatestSupportedVersionTags -Specs $Specifications
+    }
 
     # Update specs, resolve sources to full path
     $Specifications | ForEach-Object {

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Get-LatestSupportedVersion.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Get-LatestSupportedVersion.ps1
@@ -1,7 +1,10 @@
 function Get-LatestSupportedVersion
 {
-    # load Windows image specifications
-    $specs = Get-BuildSpecifications -Path (Join-Path $PSScriptRoot "\..\..\..\..\windows")
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [array]$Specs
+    )
 
     # get the latest version number for Sitecore
     $sitecore = Get-LatestVersionNumberForTag -Specs $specs -Tag "sitecore-*:*windowsservercore-*"

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -15,7 +15,7 @@ function Invoke-Build
         [string]$Registry
         ,
         [Parameter(Mandatory = $false)]
-        [array]$Tags = (Get-LatestSupportedVersionTags)
+        [array]$Tags
         ,
         [Parameter(Mandatory = $false)]
         [array]$AutoGenerateWindowsVersionTags = (Get-SupportedWindowsVersions)
@@ -51,8 +51,13 @@ function Invoke-Build
     # Load packages
     $packages = Get-Packages
 
+    $allSpecs = Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags
+    if ($Tags -eq $null)
+    {
+        $Tags = Get-LatestSupportedVersionTags -Specs $allSpecs
+    }
     # Find out what to build
-    $specs = Initialize-BuildSpecifications -Specifications (Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags) -InstallSourcePath $InstallSourcePath -Tags $Tags -ImplicitTagsBehavior $ImplicitTagsBehavior -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
+    $specs = Initialize-BuildSpecifications -Specifications $allSpecs -InstallSourcePath $InstallSourcePath -Tags $Tags -ImplicitTagsBehavior $ImplicitTagsBehavior -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
 
     # Print results
     $specs | Select-Object -Property Tag, Include, Deprecated, Priority, Base | Format-Table

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -52,10 +52,12 @@ function Invoke-Build
     $packages = Get-Packages
 
     $allSpecs = Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags
+
     if ($Tags -eq $null)
     {
         $Tags = Get-LatestSupportedVersionTags -Specs $allSpecs
     }
+
     # Find out what to build
     $specs = Initialize-BuildSpecifications -Specifications $allSpecs -InstallSourcePath $InstallSourcePath -Tags $Tags -ImplicitTagsBehavior $ImplicitTagsBehavior -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
 

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-PackageRestore.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-PackageRestore.ps1
@@ -54,10 +54,12 @@ function Invoke-PackageRestore
 
     # Find out which files is needed
     $allSpecs = Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags
+
     if ($Tags -eq $null)
     {
         $Tags = Get-LatestSupportedVersionTags -Specs $allSpecs
     }
+
     $specs = Initialize-BuildSpecifications -Specifications $allSpecs -InstallSourcePath $Destination -Tags $Tags -ImplicitTagsBehavior "Include" -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
     $expected = $specs | Where-Object { $_.Include -and $_.Sources.Length -gt 0 } | Select-Object -ExpandProperty Sources -Unique
 


### PR DESCRIPTION
Tried to reduce the number of times that the specs have to be loaded from disk. I found that numerous calls were made to the `Get-BuildSpecifications` function. When debugging in VSCode it took forever! It is however reasonable without debugging.

Also made an adjustment to the build.ps1 to not build two images unless the right topology was chosen.