### PR TITLE
Format build messages

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -31,7 +31,7 @@ param(
     [switch]$IncludeSxa,
     [Parameter()]
     [switch]$IncludeJss,
-    [Parameter(HelpMessage="If the docker image is already built it should be skipped.")]
+    [Parameter(HelpMessage = "If the docker image is already built it should be skipped.")]
     [switch]$SkipExistingImage,
     [Parameter()]
     [switch]$IncludeExperimental
@@ -56,12 +56,28 @@ $windowsVersionMapping = @{
     "ltsc2019" = "1809"
 }
 
-filter WindowsFilter { param([string]$Version) if($_ -like "*-windowsservercore-$($Version)" -or $_ -like "*-nanoserver-$($windowsVersionMapping[$Version])") { $_ } }
-filter SitecoreFilter { param([string]$Version) if($_ -like "*:$($Version)-windowsservercore-*" -or $_ -like "*:$($Version)-nanoserver-*") { $_ } }
+filter WindowsFilter
+{
+    param([string]$Version)
+    if ($_ -like "*-windowsservercore-$($Version)" -or $_ -like "*-nanoserver-$($windowsVersionMapping[$Version])")
+    {
+        $_
+    }
+}
+
+filter SitecoreFilter
+{
+    param([string]$Version)
+    if ($_ -like "*:$($Version)-windowsservercore-*" -or $_ -like "*:$($Version)-nanoserver-*")
+    {
+        $_
+    }
+}
 
 $availableSpecs = Get-BuildSpecifications -Path (Join-Path $PSScriptRoot "\windows")
 
-if(!$IncludeExperimental) {
+if (!$IncludeExperimental)
+{
     Write-Host "Excluding experimental images."
     $availableSpecs = $availableSpecs | Where-Object { !$_.Experimental }
 }
@@ -110,65 +126,65 @@ foreach ($wv in $WindowsVersion)
         $assetTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         $catchAllTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
 
-        if($Topology -contains "xm")
+        if ($Topology -contains "xm")
         {
             $xmTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         }
 
-        if($Topology -contains "xp")
+        if ($Topology -contains "xp")
         {
             $xpTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         }
 
-        if($Topology -contains "xc")
+        if ($Topology -contains "xc")
         {
             $xcTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
         }
 
-        if($IncludeSpe)
+        if ($IncludeSpe)
         {
-            if($Topology -contains "xm")
+            if ($Topology -contains "xm")
             {
                 $xmSpeTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xp")
+            if ($Topology -contains "xp")
             {
                 $xpSpeTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xc")
+            if ($Topology -contains "xc")
             {
                 $xcSpeTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
         }
 
-        if($IncludeSxa)
+        if ($IncludeSxa)
         {
-            if($Topology -contains "xm")
+            if ($Topology -contains "xm")
             {
                 $xmSxaTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xp")
+            if ($Topology -contains "xp")
             {
                 $xpSxaTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xc")
+            if ($Topology -contains "xc")
             {
                 $xcSxaTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
         }
 
-        if($IncludeJss)
+        if ($IncludeJss)
         {
-            if($Topology -contains "xm")
+            if ($Topology -contains "xm")
             {
                 $xmJssTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
 
-            if($Topology -contains "xp")
+            if ($Topology -contains "xp")
             {
                 $xpJssTags | SitecoreFilter -Version $scv | WindowsFilter -Version $wv | ForEach-Object { $tags.Add($_) > $null }
             }
@@ -209,7 +225,7 @@ SitecoreImageBuilder\Invoke-PackageRestore `
     -SitecoreUsername $SitecoreUsername `
     -SitecorePassword $SitecorePassword `
     -Tags $tags `
-    -ExperimentalTagBehavior:(@{$true="Include";$false="Skip"}[$IncludeExperimental -eq $true]) `
+    -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
     -WhatIf:$WhatIfPreference
 
 # start the build
@@ -218,5 +234,5 @@ SitecoreImageBuilder\Invoke-Build `
     -InstallSourcePath $InstallSourcePath `
     -Registry $Registry `
     -Tags $tags `
-    -ExperimentalTagBehavior:(@{$true="Include";$false="Skip"}[$IncludeExperimental -eq $true]) `
+    -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
     -WhatIf:$WhatIfPreference

--- a/Build.ps1
+++ b/Build.ps1
@@ -176,7 +176,7 @@ foreach ($wv in $WindowsVersion)
     }
 }
 
-$tags = $tags | Select-Object -Unique
+$tags = [System.Collections.ArrayList]@($tags | Select-Object -Unique)
 
 if ($SkipExistingImage)
 {

--- a/Build.ps1
+++ b/Build.ps1
@@ -5,7 +5,7 @@
 param(
     [Parameter()]
     [ValidateNotNullOrEmpty()]
-    [string]$InstallSourcePath = (Join-Path $PSScriptRoot "\packages"),
+    [string]$InstallSourcePath,
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string]$SitecoreUsername,
@@ -35,6 +35,11 @@ param(
     [switch]$SkipExistingImage
 )
 
+if ([string]::IsNullOrEmpty($InstallSourcePath))
+{
+    $InstallSourcePath = (Join-Path -Path $PSScriptRoot -ChildPath "\packages")
+}
+
 $ErrorActionPreference = "STOP"
 $ProgressPreference = "SilentlyContinue"
 
@@ -42,11 +47,11 @@ $ProgressPreference = "SilentlyContinue"
 Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -RequiredVersion 1.0.0 -Force
 
 $tags = [System.Collections.ArrayList]@()
+
 $windowsVersionMapping = @{
     "1909"     = "1909"
     "1903"     = "1903"
     "ltsc2019" = "1809"
-    "1803"     = "1803"
 }
 foreach ($wv in $WindowsVersion)
 {

--- a/Build.ps1
+++ b/Build.ps1
@@ -56,9 +56,17 @@ $windowsVersionMapping = @{
 foreach ($wv in $WindowsVersion)
 {
     $tags.Add("mssql-developer:2017-windowsservercore-$($wv)") > $null
-    $tags.Add("sitecore-certificates:latest-nanoserver-$($windowsVersionMapping[$wv])") > $null
     $tags.Add("sitecore-openjdk:8-nanoserver-$($windowsVersionMapping[$wv])") > $null
-    $tags.Add("sitecore-redis:3.0.504-windowsservercore-$($wv)") > $null
+
+    if ($Topology -contains "xp" -or $Topology -contains "xc")
+    {
+        $tags.Add("sitecore-certificates:latest-nanoserver-$($windowsVersionMapping[$wv])") > $null
+    }
+
+    if ($Topology -contains "xc")
+    {
+        $tags.Add("sitecore-redis:3.0.504-windowsservercore-$($wv)") > $null
+    }
 
     foreach ($scv in $SitecoreVersion)
     {

--- a/Build.ps1
+++ b/Build.ps1
@@ -37,6 +37,17 @@ param(
     [switch]$IncludeExperimental
 )
 
+function Write-Message
+{
+    param(
+        [string]$Message
+    )
+
+    $timeFormat = "HH:mm:ss:fff"
+
+    Write-Host "$(Get-Date -Format $timeFormat): $($Message)"
+}
+
 if ([string]::IsNullOrEmpty($InstallSourcePath))
 {
     $InstallSourcePath = (Join-Path -Path $PSScriptRoot -ChildPath "\packages")
@@ -78,7 +89,7 @@ $availableSpecs = Get-BuildSpecifications -Path (Join-Path $PSScriptRoot "\windo
 
 if (!$IncludeExperimental)
 {
-    Write-Host "Excluding experimental images."
+    Write-Message "Excluding experimental images."
     $availableSpecs = $availableSpecs | Where-Object { !$_.Experimental }
 }
 
@@ -196,7 +207,7 @@ $tags = [System.Collections.ArrayList]@($tags | Select-Object -Unique)
 
 if ($SkipExistingImage)
 {
-    Write-Host "Existing images will be excluded from the build."
+    Write-Message "Existing images will be excluded from the build."
     $existingImages = docker images --format '{{.Repository}}:{{.Tag}}' --filter 'dangling=false'
     foreach ($existingImage in $existingImages)
     {
@@ -209,12 +220,12 @@ if ($SkipExistingImage)
 
 if ($tags)
 {
-    Write-Host "The following images will be built:"
+    Write-Message "The following images will be built:"
     $tags
 }
 else
 {
-    Write-Host "No images need to be built."
+    Write-Message "No images need to be built."
     exit
 }
 

--- a/modules/SitecoreImageBuilder/1.0.0/Private/Get-LatestSupportedVersionTags.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Private/Get-LatestSupportedVersionTags.ps1
@@ -1,6 +1,12 @@
 function Get-LatestSupportedVersionTags
 {
-    $latest = Get-LatestSupportedVersion
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [array]$Specs
+    )
+
+    $latest = Get-LatestSupportedVersion -Specs $Specs
 
     Write-Output ("*:{0}*{1}" -f $latest.Sitecore, $latest.WindowsServerCore)
     Write-Output ("*:{0}*{1}" -f $latest.Sitecore, $latest.NanoServer)

--- a/modules/SitecoreImageBuilder/1.0.0/Private/Initialize-BuildSpecifications.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Private/Initialize-BuildSpecifications.ps1
@@ -10,7 +10,7 @@ function Initialize-BuildSpecifications
         [string]$InstallSourcePath
         ,
         [Parameter(Mandatory = $false)]
-        [array]$Tags = (Get-LatestSupportedVersionTags)
+        [array]$Tags
         ,
         [Parameter(Mandatory = $false)]
         [ValidateSet("Include", "Skip")]
@@ -24,6 +24,11 @@ function Initialize-BuildSpecifications
         [ValidateSet("Include", "Skip")]
         [string]$ExperimentalTagBehavior = "Skip"
     )
+
+    if ($Tags -eq $null)
+    {
+        $Tags = Get-LatestSupportedVersionTags -Specs $Specifications
+    }
 
     # Update specs, resolve sources to full path
     $Specifications | ForEach-Object {

--- a/modules/SitecoreImageBuilder/1.0.0/Private/Initialize-BuildSpecifications.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Private/Initialize-BuildSpecifications.ps1
@@ -52,14 +52,14 @@ function Initialize-BuildSpecifications
         {
             $spec.Include = $false
 
-            Write-Verbose ("Tag '{0}' excluded as it is deprecated and the DeprecatedTagsBehavior parameter is '{1}'." -f $spec.Tag, $DeprecatedTagsBehavior)
+            Write-Message ("Tag '{0}' excluded as it is deprecated and the DeprecatedTagsBehavior parameter is '{1}'." -f $spec.Tag, $DeprecatedTagsBehavior) -Level Verbose
         }
 
         if ($spec.Include -eq $true -and $spec.Experimental -eq $true -and $ExperimentalTagBehavior -eq "Skip")
         {
             $spec.Include = $false
 
-            Write-Verbose ("Tag '{0}' excluded as it is experimental and the ExperimentalTagBehavior parameter is '{1}'." -f $spec.Tag, $ExperimentalTagBehavior)
+            Write-Message ("Tag '{0}' excluded as it is experimental and the ExperimentalTagBehavior parameter is '{1}'." -f $spec.Tag, $ExperimentalTagBehavior) -Level Verbose
         }
     }
 
@@ -78,7 +78,7 @@ function Initialize-BuildSpecifications
                     $baseSpec = $_
                     $baseSpec.Include = $true
 
-                    Write-Verbose ("Tag '{0}' implicitly included '{1}' due to dependency." -f $spec.Tag, $baseSpec.Tag)
+                    Write-Message ("Tag '{0}' implicitly included '{1}' due to dependency." -f $spec.Tag, $baseSpec.Tag) -Level Verbose
                 }
 
                 $baseSpecs = @($Specifications | Where-Object { $_.Include -eq $false -and $baseSpecs.Base -contains $_.Tag })

--- a/modules/SitecoreImageBuilder/1.0.0/Private/Write-Message.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Private/Write-Message.ps1
@@ -1,0 +1,55 @@
+enum MessageLevel
+{
+    Debug
+    Info
+    Warning
+    Verbose
+    Error
+}
+function Write-Message
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Message,
+        [Parameter()]
+        [MessageLevel]$Level = [MessageLevel]::Info
+    )
+
+    $timeFormat = "HH:mm:ss:fff"
+
+    $formattedMessage = "$(Get-Date -Format $timeFormat): $($Message)"
+
+    switch ($Level)
+    {
+        ([MessageLevel]::Debug)
+        {
+            Write-Host $formattedMessage -ForegroundColor Cyan
+            break
+        }
+        ([MessageLevel]::Info)
+        {
+            Write-Host $formattedMessage -ForegroundColor Green
+            break
+        }
+        ([MessageLevel]::Verbose)
+        {
+            Write-Verbose $formattedMessage
+            break
+        }
+        ([MessageLevel]::Warning)
+        {
+            Write-Warning $formattedMessage
+            break
+        }
+        ([MessageLevel]::Error)
+        {
+            Write-Error $formattedMessage
+            break
+        }
+        default
+        {
+            Write-Host $formattedMessage -ForegroundColor Green
+        }
+    }
+}

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Get-LatestSupportedVersion.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Get-LatestSupportedVersion.ps1
@@ -1,7 +1,10 @@
 function Get-LatestSupportedVersion
 {
-    # load Windows image specifications
-    $specs = Get-BuildSpecifications -Path (Join-Path $PSScriptRoot "\..\..\..\..\windows")
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [array]$Specs
+    )
 
     # get the latest version number for Sitecore
     $sitecore = Get-LatestVersionNumberForTag -Specs $specs -Tag "sitecore-*:*windowsservercore-*"

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -15,7 +15,7 @@ function Invoke-Build
         [string]$Registry
         ,
         [Parameter(Mandatory = $false)]
-        [array]$Tags = (Get-LatestSupportedVersionTags)
+        [array]$Tags
         ,
         [Parameter(Mandatory = $false)]
         [array]$AutoGenerateWindowsVersionTags = (Get-SupportedWindowsVersions)
@@ -51,8 +51,13 @@ function Invoke-Build
     # Load packages
     $packages = Get-Packages
 
+    $allSpecs = Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags
+    if ($Tags -eq $null)
+    {
+        $Tags = Get-LatestSupportedVersionTags -Specs $allSpecs
+    }
     # Find out what to build
-    $specs = Initialize-BuildSpecifications -Specifications (Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags) -InstallSourcePath $InstallSourcePath -Tags $Tags -ImplicitTagsBehavior $ImplicitTagsBehavior -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
+    $specs = Initialize-BuildSpecifications -Specifications $allSpecs -InstallSourcePath $InstallSourcePath -Tags $Tags -ImplicitTagsBehavior $ImplicitTagsBehavior -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
 
     # Print results
     $specs | Select-Object -Property Tag, Include, Deprecated, Priority, Base | Format-Table

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -1,3 +1,17 @@
+class ReportRecord
+{
+    [string]$Name
+    [string]$Time
+    [int]$Index
+
+    ReportRecord([string]$Name, [string]$Time, [int]$Index)
+    {
+        $this.Name = $Name
+        $this.Time = $Time
+        $this.Index = $Index
+    }
+}
+
 function Invoke-Build
 {
     [CmdletBinding(SupportsShouldProcess = $true)]
@@ -48,6 +62,9 @@ function Invoke-Build
     $ErrorActionPreference = "STOP"
     $ProgressPreference = "SilentlyContinue"
 
+    $watch = [System.Diagnostics.StopWatch]::StartNew()
+    $reportRecords = [System.Collections.Generic.List[ReportRecord]]@()
+
     # Load packages
     $packages = Get-Packages
 
@@ -67,7 +84,7 @@ function Invoke-Build
     # Determine OS
     $osType = (docker system info --format '{{json .}}' | ConvertFrom-Json | ForEach-Object { $_.OSType })
 
-    Write-Host "### Build specifications loaded..." -ForegroundColor Green
+    Write-Message "Build specifications loaded..." -Level Info
 
     # Pull latest external images
     if ($PSCmdlet.ShouldProcess("Pull latest images"))
@@ -93,25 +110,29 @@ function Invoke-Build
 
                 $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw "Failed." }
 
-                Write-Host ("### External image '{0}' is latest." -f $tag)
+                Write-Message ("External image '{0}' is latest." -f $tag) -Level Debug
             }
 
-            Write-Host "### External images is up to date..." -ForegroundColor Green
+            Write-Message "External images are up to date..." -Level Debug
         }
         else
         {
-            Write-Warning ("### Pulling external images skipped since PullMode was '{0}'." -f $PullMode)
+            Write-Message ("Pulling external images skipped since PullMode was '{0}'." -f $PullMode) -Level Warning
         }
     }
 
     # Start build...
     if ($PSCmdlet.ShouldProcess("Start image builds"))
     {
+        $currentCount = 0
+        $totalCount = $specs | Where-Object { $_.Include } | Measure-Object | Select-Object -ExpandProperty Count
         $specs | Where-Object { $_.Include } | ForEach-Object {
             $spec = $_
             $tag = $spec.Tag
+            $currentCount++
+            Write-Message "Processing $($currentCount) of $($totalCount) '$($tag)'..."
 
-            Write-Host ("### Processing '{0}'..." -f $tag)
+            $currentWatch = [System.Diagnostics.StopWatch]::StartNew()
 
             # Save the digest of previous builds for later comparison
             $previousDigest = $null
@@ -128,7 +149,7 @@ function Invoke-Build
                 # Continue if source file doesn't exist
                 if (!(Test-Path $sourcePath))
                 {
-                    Write-Warning "Optional source file '$sourcePath' is missing..."
+                    Write-Message "Optional source file '$sourcePath' is missing..." -Level Warning
 
                     return
                 }
@@ -143,7 +164,7 @@ function Invoke-Build
                 }
 
                 # Check to see if we can lookup the hash of the source filename in sitecore-packages.json
-                if (!$SkipHashValidation.IsPresent)
+                if (!$SkipHashValidation)
                 {
                     $package = $packages."$($sourceItem.Name)"
 
@@ -157,7 +178,7 @@ function Invoke-Build
                         # Compare hashes and fail if not the same
                         if ($currentTargetFileHash -eq $expectedTargetFileHash)
                         {
-                            Write-Host ("### Hash of '{0}' is valid." -f $sourceItem.Name)
+                            Write-Message ("Hash of '{0}' is valid." -f $sourceItem.Name) -Level Debug
                         }
                         else
                         {
@@ -168,7 +189,7 @@ function Invoke-Build
                     }
                     else
                     {
-                        Write-Verbose ("Skipping hash validation on '{0}', package was not found or no hash was defined." -f $sourceItem.Name)
+                        Write-Message ("Skipping hash validation on '{0}', package was not found or no hash was defined." -f $sourceItem.Name) -Level Verbose
                     }
                 }
             }
@@ -191,16 +212,20 @@ function Invoke-Build
 
             $buildCommand = "docker image build {0} '{1}'" -f ($buildOptions -join " "), $spec.Path
 
-            Write-Verbose ("Invoking: {0} " -f $buildCommand) -Verbose:$VerbosePreference
+            Write-Message ("Invoking: {0} " -f $buildCommand) -Level Verbose -Verbose:$VerbosePreference
 
             & ([scriptblock]::create($buildCommand))
 
             $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw "Failed: $buildCommand" }
 
+            $currentWatch.Stop()
+            Write-Message "Build completed for $($tag). Time: $($currentWatch.Elapsed.ToString("hh\:mm\:ss\.fff"))." -Level Debug
+            $reportRecords.Add(([ReportRecord]::new($tag, $currentWatch.Elapsed.ToString("hh\:mm\:ss\.fff"), $currentCount))) > $null
+
             # Check to see if we need to stop here...
             if ([string]::IsNullOrEmpty($Registry))
             {
-                Write-Host ("### Done with '{0}', but not pushed since 'Registry' was empty." -f $tag) -ForegroundColor Green
+                Write-Message ("Done with '{0}', but not pushed since 'Registry' was empty." -f $tag) -Level Debug
 
                 return
             }
@@ -222,7 +247,7 @@ function Invoke-Build
             # Check to see if we need to stop here...
             if ($PushMode -eq "Never")
             {
-                Write-Host ("### Done with '{0}', but not pushed since 'PushMode' is '{1}'." -f $tag, $PushMode) -ForegroundColor Green
+                Write-Message ("Processing complete for '{0}', but not pushed since 'PushMode' is '{1}'." -f $tag, $PushMode)
 
                 return
             }
@@ -232,7 +257,7 @@ function Invoke-Build
 
             if (($PushMode -eq "WhenChanged") -and ($currentDigest -eq $previousDigest))
             {
-                Write-Host ("### Done with '{0}', but not pushed since 'PushMode' is '{1}' and the image has not changed since last build." -f $tag, $PushMode) -ForegroundColor Green
+                Write-Message ("Processing complete for '{0}', but not pushed since 'PushMode' is '{1}' and the image has not changed since last build." -f $tag, $PushMode)
 
                 return
             }
@@ -242,7 +267,12 @@ function Invoke-Build
 
             $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw "Failed." }
 
-            Write-Host ("### Done with '{0}', image pushed." -f $fulltag) -ForegroundColor Green
+            Write-Message ("Processing complete for '{0}', image pushed." -f $fulltag)
         }
     }
+
+    $watch.Stop()
+    Write-Message "Builds completed. Time: $($watch.Elapsed.ToString("hh\:mm\:ss\.fff"))."
+
+    Write-Output $reportRecords | Format-Table -Property Index, Time, Name
 }

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -52,10 +52,12 @@ function Invoke-Build
     $packages = Get-Packages
 
     $allSpecs = Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags
+
     if ($Tags -eq $null)
     {
         $Tags = Get-LatestSupportedVersionTags -Specs $allSpecs
     }
+
     # Find out what to build
     $specs = Initialize-BuildSpecifications -Specifications $allSpecs -InstallSourcePath $InstallSourcePath -Tags $Tags -ImplicitTagsBehavior $ImplicitTagsBehavior -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
 

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-PackageRestore.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-PackageRestore.ps1
@@ -54,10 +54,12 @@ function Invoke-PackageRestore
 
     # Find out which files is needed
     $allSpecs = Get-BuildSpecifications -Path $Path -AutoGenerateWindowsVersionTags $AutoGenerateWindowsVersionTags
+
     if ($Tags -eq $null)
     {
         $Tags = Get-LatestSupportedVersionTags -Specs $allSpecs
     }
+
     $specs = Initialize-BuildSpecifications -Specifications $allSpecs -InstallSourcePath $Destination -Tags $Tags -ImplicitTagsBehavior "Include" -DeprecatedTagsBehavior $DeprecatedTagsBehavior -ExperimentalTagBehavior $ExperimentalTagBehavior
     $expected = $specs | Where-Object { $_.Include -and $_.Sources.Length -gt 0 } | Select-Object -ExpandProperty Sources -Unique
 

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-PackageRestore.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-PackageRestore.ps1
@@ -38,6 +38,8 @@ function Invoke-PackageRestore
     $ErrorActionPreference = "STOP"
     $ProgressPreference = "SilentlyContinue"
 
+    $watch = [System.Diagnostics.StopWatch]::StartNew()
+
     $sitecoreDownloadUrl = "https://dev.sitecore.net"
     $destinationPath = $Destination.TrimEnd('\')
 
@@ -73,7 +75,7 @@ function Invoke-PackageRestore
 
             if ($requiredFile.Length -gt 0)
             {
-                Write-Host ("Required package found: '{0}'" -f $filePath)
+                Write-Message ("Required package found: '{0}'" -f $filePath) -Level Debug
 
                 return
             }
@@ -93,21 +95,20 @@ function Invoke-PackageRestore
 
         if ([string]::IsNullOrEmpty($fileUrl))
         {
-            Write-Warning ("Required package '{0}' not available for download because the url property is empty, please copy '{0}' into '{1}' manually." -f $fileName, $Destination)
+            Write-Message ("Required package '{0}' not available for download because the url property is empty, please copy '{0}' into '{1}' manually." -f $fileName, $Destination) -Level Warning
         }
         else
         {
-
             if ($PSCmdlet.ShouldProcess($fileName))
             {
-                Write-Host ("Downloading '{0}' to '{1}'..." -f $fileUrl, $filePath)
+                Write-Message ("Downloading '{0}' to '{1}'..." -f $fileUrl, $filePath)
 
                 if ($fileUrl.StartsWith($sitecoreDownloadUrl))
                 {
                     # Login to dev.sitecore.net and save session for re-use
                     if ($null -eq $sitecoreDownloadSession)
                     {
-                        Write-Verbose ("Logging in to '{0}'..." -f $sitecoreDownloadUrl)
+                        Write-Message ("Logging in to '{0}'..." -f $sitecoreDownloadUrl) -Level Verbose
 
                         $loginResponse = Invoke-WebRequest "https://dev.sitecore.net/api/authorization" -Method Post -Body @{
                             username   = $SitecoreUsername
@@ -120,7 +121,7 @@ function Invoke-PackageRestore
                             throw ("Unable to login to '{0}' with the supplied credentials." -f $sitecoreDownloadUrl)
                         }
 
-                        Write-Verbose ("Logged in to '{0}'." -f $sitecoreDownloadUrl)
+                        Write-Message ("Logged in to '{0}'." -f $sitecoreDownloadUrl) -Level Verbose
                     }
 
                     # Download package using saved session
@@ -135,5 +136,6 @@ function Invoke-PackageRestore
         }
     }
 
-    Write-Host "Restore completed."
+    $watch.Stop()
+    Write-Message "Restore completed. Time: $($watch.Elapsed.ToString("hh\:mm\:ss\.fff"))."
 }


### PR DESCRIPTION
#204 provides a cleaner output for the user.

Is it necessary to always output the complete list of images?

![image](https://user-images.githubusercontent.com/933163/72671088-eee09100-3a0a-11ea-9036-ee1b83c0bf19.png)
