### PR TITLE
Converted BizFX to use HTTPS

### DIFF
--- a/windows/9.2.x/sitecore-xc-bizfx/Dockerfile
+++ b/windows/9.2.x/sitecore-xc-bizfx/Dockerfile
@@ -62,5 +62,14 @@ RUN $env:INSTALL_TEMP = 'C:\\inetpub\\wwwroot\\temp\\install'; `
         $acl.SetAccessRule($rule); `
         $acl | Set-Acl -Path $path; `
     }; `
+    # configure SSL binding because Identity insists on sending the user back to bizfx using https
+    $env:IIS_SITE_NAME = 'Default Web Site'; `
+    Import-Module WebAdministration; `
+    $bizfxCert = Import-PfxCertificate -FilePath (Join-Path $env:INSTALL_TEMP '\\certificates\\bizfx.pfx') -CertStoreLocation 'cert:\localmachine\my' -Password $password; `
+    New-WebBinding -Name $env:IIS_SITE_NAME -IPAddress '*' -Port '443' -Protocol "https" -HostHeader '*'; `
+    $binding = Get-WebBinding -Name $env:IIS_SITE_NAME -Protocol "https"; `
+    $binding.AddSslCertificate($bizfxCert.GetCertHashString(), 'my'); `
+    # configure SSL flags
+    Set-WebConfigurationProperty -PSPath 'machine/webroot/apphost' -Filter 'system.webServer/security/access' -Name 'sslFlags' -Value 'SslNegotiateCert'; `
     # delete temporary files
     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse;

--- a/windows/9.2.x/sitecore-xc-bizfx/assets/config.json
+++ b/windows/9.2.x/sitecore-xc-bizfx/assets/config.json
@@ -2,7 +2,7 @@
     "EnvironmentName": "HabitatAuthoring",
     "EngineUri": "http://commerce-authoring",
     "IdentityServerUri": "https://identity",
-    "BizFxUri": "http://bizfx",
+    "BizFxUri": "https://bizfx",
     "Language": "en",
     "Currency": "USD",
     "ShopName": "CommerceEngineDefaultStorefront",

--- a/windows/9.2.x/sitecore-xc-engine/config/authoring/config.json
+++ b/windows/9.2.x/sitecore-xc-engine/config/authoring/config.json
@@ -10,7 +10,7 @@
     "EncryptionKeyStorageLocation": "c:\\Encryption-Keys\\",
     "SitecoreIdentityServerUrl": "https://identity",
     "AllowedOrigins": [
-      "http://bizfx",
+      "https://bizfx",
       "http://cd",
       "http://cm"
     ],

--- a/windows/9.2.x/sitecore-xc-engine/config/minions/config.json
+++ b/windows/9.2.x/sitecore-xc-engine/config/minions/config.json
@@ -10,7 +10,7 @@
     "EncryptionKeyStorageLocation": "c:\\Encryption-Keys\\",
     "SitecoreIdentityServerUrl": "https://identity",
     "AllowedOrigins": [
-      "http://bizfx",
+      "https://bizfx",
       "http://cd",
       "http://cm"
     ],

--- a/windows/9.2.x/sitecore-xc-engine/config/ops/config.json
+++ b/windows/9.2.x/sitecore-xc-engine/config/ops/config.json
@@ -10,7 +10,7 @@
     "EncryptionKeyStorageLocation": "c:\\Encryption-Keys\\",
     "SitecoreIdentityServerUrl": "https://identity",
     "AllowedOrigins": [
-      "http://bizfx",
+      "https://bizfx",
       "http://cd",
       "http://cm"
     ],

--- a/windows/9.2.x/sitecore-xc-engine/config/shops/config.json
+++ b/windows/9.2.x/sitecore-xc-engine/config/shops/config.json
@@ -10,7 +10,7 @@
     "EncryptionKeyStorageLocation": "c:\\Encryption-Keys\\",
     "SitecoreIdentityServerUrl": "https://identity",
     "AllowedOrigins": [
-      "http://bizfx",
+      "https://bizfx",
       "http://cd",
       "http://cm"
     ],

--- a/windows/9.2.x/sitecore-xc-identity/config/production/Sitecore.Commerce.IdentityServer.Host.xml
+++ b/windows/9.2.x/sitecore-xc-identity/config/production/Sitecore.Commerce.IdentityServer.Host.xml
@@ -24,7 +24,7 @@
             <PostLogoutRedirectUri1>{AllowedCorsOrigin}</PostLogoutRedirectUri1>
           </PostLogoutRedirectUris>
           <AllowedCorsOrigins>
-            <AllowedCorsOriginsGroup1>http://commerce-authoring|http://bizfx</AllowedCorsOriginsGroup1>
+            <AllowedCorsOriginsGroup1>http://commerce-authoring|https://bizfx</AllowedCorsOriginsGroup1>
           </AllowedCorsOrigins>
           <AllowedScopes>
             <AllowedScope1>openid</AllowedScope1>

--- a/windows/dependencies/sitecore-certificates/Dockerfile
+++ b/windows/dependencies/sitecore-certificates/Dockerfile
@@ -12,6 +12,7 @@ RUN $env:ROOT_CERT_NAME = 'sitecore-root'; `
     $env:COMMERCE_CLIENT_CERT_NAME = 'commerce-client'; `
     $env:IDENTITY_CLIENT_CERT_NAME = 'identity-client'; `
     $env:IDENTITY_SSL_CERT_NAME = 'identity'; `
+    $env:BIZFX_SSL_CERT_NAME = 'bizfx'; `
     $env:CM_SSL_CERT_NAME = 'cm'; `
     $env:CERT_STORE = 'Cert:\LocalMachine\My'; `
     $env:CERT_PASSWORD = 'Twelve4-4Cranial-Rag-kayo4-Ragweed-This8-grunge9-0Foss-7finalist-hubby'; `
@@ -24,6 +25,7 @@ RUN $env:ROOT_CERT_NAME = 'sitecore-root'; `
     New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:COMMERCE_CLIENT_CERT_NAME -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:COMMERCE_CLIENT_CERT_NAME) -Password $password | Out-Null; `
     New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:IDENTITY_CLIENT_CERT_NAME -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:IDENTITY_CLIENT_CERT_NAME) -Password $password | Out-Null; `
     New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:IDENTITY_SSL_CERT_NAME, '127.0.0.1', 'localhost' -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:IDENTITY_SSL_CERT_NAME) -Password $password | Out-Null; `
+    New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:BIZFX_SSL_CERT_NAME, '127.0.0.1', 'localhost' -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:BIZFX_SSL_CERT_NAME) -Password $password | Out-Null; `
     New-SelfSignedCertificate -CertStoreLocation $env:CERT_STORE -DnsName $env:CM_SSL_CERT_NAME, '127.0.0.1', 'localhost' -Signer $rootCert -KeyExportPolicy 'Exportable' -Provider 'Microsoft Enhanced RSA and AES Cryptographic Provider' | Export-PfxCertificate -FilePath ('C:\\certificates\\{1}.pfx' -f $env:CERT_PATH, $env:CM_SSL_CERT_NAME) -Password $password | Out-Null; `
     Import-PfxCertificate -FilePath ('C:\\certificates\\sitecore-root.pfx') -CertStoreLocation 'cert:\localmachine\root' -Password $password | Out-Null; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:ROOT_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:ROOT_CERT_NAME) -NoNewline -Encoding utf8; `
@@ -32,6 +34,7 @@ RUN $env:ROOT_CERT_NAME = 'sitecore-root'; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:COMMERCE_CLIENT_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:COMMERCE_CLIENT_CERT_NAME) -NoNewline -Encoding utf8; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:IDENTITY_CLIENT_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:IDENTITY_CLIENT_CERT_NAME) -NoNewline -Encoding utf8; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:IDENTITY_SSL_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:IDENTITY_SSL_CERT_NAME) -NoNewline -Encoding utf8; `
+    (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:BIZFX_SSL_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:BIZFX_SSL_CERT_NAME) -NoNewline -Encoding utf8; `
     (Get-ChildItem -Path $env:CERT_STORE | Where-Object { $_.Subject -eq ('CN={0}' -f $env:CM_SSL_CERT_NAME ) }).Thumbprint | Out-File -FilePath ('C:\\certificates\\{0}.thumbprint' -f $env:CM_SSL_CERT_NAME) -NoNewline -Encoding utf8; `
     $env:CERT_PASSWORD | Out-File -FilePath 'C:\\certificates\\password' -NoNewline -Encoding utf8;
 

--- a/windows/tests/9.2.x/README.md
+++ b/windows/tests/9.2.x/README.md
@@ -40,7 +40,7 @@ Once all containers are running, perform the following Sitecore Commerce post-in
 
 To verify that everything is working okay browse to:
 
-    1. [BizFx](http://localhost:4200) and verify that Habitat catalog is present
+    1. [BizFx](https://localhost:4200) and verify that Habitat catalog is present
     2. [CM](http://localhost:44001/sitecore) and verify that Habitat catalog is present under `/sitecore/Commerce/Catalog Management/Catalogs`
 
 > The Business Tools run at HTTP and *not* HTTPS. When browsing to the Business Tools from the Control Panel remove the *S* from the address.

--- a/windows/tests/9.2.x/docker-compose.xc.spe.yml
+++ b/windows/tests/9.2.x/docker-compose.xc.spe.yml
@@ -128,7 +128,7 @@ services:
   bizfx:
     image: ${REGISTRY}sitecore-xc-bizfx:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     ports:
-      - "4200:80"
+      - "4200:443"
     links:
       - commerce-authoring
       - identity

--- a/windows/tests/9.2.x/docker-compose.xc.sxa.storefront.yml
+++ b/windows/tests/9.2.x/docker-compose.xc.sxa.storefront.yml
@@ -128,7 +128,7 @@ services:
   bizfx:
     image: ${REGISTRY}sitecore-xc-bizfx:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     ports:
-      - "4200:80"
+      - "4200:443"
     links:
       - commerce-authoring
       - identity

--- a/windows/tests/9.2.x/docker-compose.xc.sxa.yml
+++ b/windows/tests/9.2.x/docker-compose.xc.sxa.yml
@@ -128,7 +128,7 @@ services:
   bizfx:
     image: ${REGISTRY}sitecore-xc-bizfx:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     ports:
-      - "4200:80"
+      - "4200:443"
     links:
       - commerce-authoring
       - identity

--- a/windows/tests/9.2.x/docker-compose.xc.yml
+++ b/windows/tests/9.2.x/docker-compose.xc.yml
@@ -133,7 +133,7 @@ services:
   bizfx:
     image: ${REGISTRY}sitecore-xc-bizfx:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     ports:
-      - "4200:80"
+      - "4200:443"
     links:
       - commerce-authoring
       - identity


### PR DESCRIPTION
Currently BizFX is running on http instead of https.
The problem with this is that identity sometime insists on sending the user back to bizfx using https, even if it is configured as http.
This fixes that problem by moving it to https.

* Added generation of bizfx certificate
* Changed dockerfile for bizfx to use the ssl certificate
* Changed config files to use bizfx over https
* Updated docker-compose files and README.md to use https and port 443