### PR TITLE
removed unused script reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ See the `cm` and `cd` service in [windows/tests/9.3.x/docker-compose.xm.yml](win
 - Same as `Production.ps1`.
 - Starts the Visual Studio Remote Debugger `msvsmon.exe` in the background **if** the Visual Studio Remote Debugger directory is mounted into `C:\remote_debugger`.
 - Starts the `Watch-Directory.ps1` script in the background **if** a directory is mounted into `C:\src`.
-  - To customize parameters you can use `WatchDirectoryParameters` and give it a hashtable, example: `entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1 -WatchDirectoryParameters @{ Path = 'C:\\src'; Destination = 'C:\\inetpub\\wwwroot'; ExcludeFiles = @('Web.config'); }"`
+  - To customize parameters you can use `WatchDirectoryParameters` and give it a hashtable, example: `entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\sitecore-xc-engine\\Development.ps1 -WatchDirectoryParameters @{ Path = 'C:\\src'; Destination = 'C:\\inetpub\\wwwroot'; ExcludeFiles = @('Web.config'); }"`
 
 See the `commerce-authoring` service in [windows/tests/9.2.x/docker-compose.xc.yml](windows/tests/9.2.x/docker-compose.xc.yml) for configuration examples.
 

--- a/windows/9.2.0/sitecore-assets/tools/entrypoints/sitecore-xc-engine/Production.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/entrypoints/sitecore-xc-engine/Production.ps1
@@ -78,9 +78,6 @@ while ($true)
 # wait for application pool to stop
 Wait-WebItemState -IISPath "IIS:\AppPools\DefaultAppPool" -State "Stopped"
 
-# Set connection string details
-c:/tools/scripts/Set-CommerceEngineConnectionString.ps1 -userName $env:SQL_USER -password $env:SQL_PASSWORD -server $env:SQL_HOST -globalDatabaseName $env:SQL_COMMERCE_GLOBAL_DB_NAME -sharedEnvironmentDatabaseName $env:SQL_COMMERCE_SHAREDENVIRONMENT_DB_NAME
-
 # start ServiceMonitor.exe in background, kill foreground process if it fails
 Start-Job -Name "ServiceMonitor.exe" {
     try


### PR DESCRIPTION
Removed an unused script reference in the XC entrypoint script from my previously merged PR. 

Having the reference there will cause an error when starting the XC container using the production entrypoint script.