### PR TITLE
More robust sql Boot.ps1

### DIFF
--- a/windows/9.3.x/sitecore-xp-sqldev/Boot.ps1
+++ b/windows/9.3.x/sitecore-xp-sqldev/Boot.ps1
@@ -28,15 +28,36 @@ else
     Write-Host "$(Get-Date -Format $timeFormat): Existing Sitecore databases found in '$DataPath'..."
 }
 
+Write-Host "$(Get-Date -Format $timeFormat): Waiting for the the MSSQLSERVER service to start..."
+(Get-Service MSSQLSERVER).WaitForStatus('Running')
+Write-Host "$(Get-Date -Format $timeFormat): MSSQLSERVER service is now running!" -ForegroundColor Green
+
 Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
     $databaseName = $_.BaseName.Replace("_Primary", "")
     $mdfPath = $_.FullName
     $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
-    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
 
-    Write-Host "$(Get-Date -Format $timeFormat): Attaching '$databaseName'..."
+    try {
+        Write-Host "$(Get-Date -Format $timeFormat): Setting single user for [$databaseName]..."
+        Invoke-Sqlcmd -Query "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') ALTER DATABASE [$databaseName] SET SINGLE_USER WITH ROLLBACK IMMEDIATE" -Querytimeout 65535 -ConnectionTimeout 65535
 
-    Invoke-Sqlcmd -Query $sqlcmd
+        Write-Host "$(Get-Date -Format $timeFormat): Reattaching '$databaseName'..."
+
+        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath') FOR ATTACH;"
+        if (Test-Path $ldfPath) {
+            $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+        }
+
+        # Pass in explicit long timeouts because by default its not infinite (in contrary to what the documentation claims)
+        Invoke-Sqlcmd -Query $sqlcmd -Querytimeout 65535 -ConnectionTimeout 65535
+    } catch {
+        $ErrorMessage = $_.Exception.Message
+        Write-Host "$(Get-Date -Format $timeFormat): The following error occurred while attaching $databaseName : $ErrorMessage"
+        Write-Host "$(Get-Date -Format $timeFormat): Repairing '$databaseName'..."
+
+        $repairCmd = "ALTER DATABASE [$databaseName] SET EMERGENCY; DBCC CHECKDB ([$databaseName], REPAIR_ALLOW_DATA_LOSS) WITH NO_INFOMSGS";
+        Invoke-Sqlcmd -Query $repairCmd -Querytimeout 65535 -ConnectionTimeout 65535
+    }
 }
 
 Write-Host "$(Get-Date -Format $timeFormat): Preparing Sitecore databases..."


### PR DESCRIPTION
I had problems with attaching databases when using process isolation (and XP 9.3).

To mitigate these problems I basically added the solution which I had before here: https://github.com/avivasolutionsnl/sitecore-docker/blob/master/xp/mssql/Boot.ps1
