### PR TITLE
#256: Add IsolationMode parameter to build.ps1

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -36,8 +36,8 @@ param(
     [Parameter()]
     [switch]$IncludeExperimental,
     [Parameter(Mandatory = $false)]
-    [ValidateSet("hyperv", "process")]
-    [string]$IsolationMode = "unspecified"
+    [ValidateSet("ForceHyperV", "EngineDefault", "ForceProcess")]
+    [string]$IsolationModeBehaviour = "ForceHyperV"
 )
 
 function Write-Message
@@ -249,5 +249,5 @@ SitecoreImageBuilder\Invoke-Build `
     -Registry $Registry `
     -Tags $tags `
     -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
-    -IsolationMode $IsolationMode `
+    -IsolationModeBehaviour $IsolationModeBehaviour `
     -WhatIf:$WhatIfPreference

--- a/Build.ps1
+++ b/Build.ps1
@@ -37,7 +37,7 @@ param(
     [switch]$IncludeExperimental,
     [Parameter(Mandatory = $false)]
     [ValidateSet("hyperv", "process")]
-    [string]$IsolationMode = $null
+    [string]$IsolationMode = "unspecified"
 )
 
 function Write-Message

--- a/Build.ps1
+++ b/Build.ps1
@@ -34,7 +34,10 @@ param(
     [Parameter(HelpMessage = "If the docker image is already built it should be skipped.")]
     [switch]$SkipExistingImage,
     [Parameter()]
-    [switch]$IncludeExperimental
+    [switch]$IncludeExperimental,
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("hyperv", "process")]
+    [string]$IsolationMode = $null
 )
 
 function Write-Message
@@ -246,4 +249,5 @@ SitecoreImageBuilder\Invoke-Build `
     -Registry $Registry `
     -Tags $tags `
     -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
+    -IsolationMode $IsolationMode `
     -WhatIf:$WhatIfPreference

--- a/Build.ps1
+++ b/Build.ps1
@@ -36,7 +36,7 @@ param(
     [Parameter()]
     [switch]$IncludeExperimental,
     [Parameter(Mandatory = $false)]
-    [ValidateSet("ForceHyperV", "EngineDefault", "ForceProcess")]
+    [ValidateSet("ForceHyperV", "EngineDefault", "ForceProcess", "ForceDefault")]
     [string]$IsolationModeBehaviour = "ForceHyperV"
 )
 

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -58,8 +58,8 @@ function Invoke-Build
         [switch]$SkipHashValidation
         ,
         [Parameter(Mandatory = $false)]
-        [ValidateSet("hyperv", "process")]
-        [string]$IsolationMode = $null
+        [ValidateSet("unspecified", "hyperv", "process")]
+        [string]$IsolationMode = "unspecified"
     )
 
     # Setup
@@ -204,7 +204,7 @@ function Invoke-Build
             if ($osType -eq "windows")
             {
                 # fix build issues on windows server core ltsc2019
-                if ($IsolationMode)
+                if (!($IsolationMode -ieq 'unspecified'))
                 {
                     $buildOptions.Add("--isolation '$IsolationMode'")
                 }

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -58,7 +58,7 @@ function Invoke-Build
         [switch]$SkipHashValidation
         ,
         [Parameter(Mandatory = $false)]
-        [ValidateSet("ForceHyperV", "EngineDefault", "ForceProcess")]
+        [ValidateSet("ForceHyperV", "EngineDefault", "ForceProcess", "ForceDefault")]
         [string]$IsolationModeBehaviour = "ForceHyperV"
     )
 
@@ -205,12 +205,16 @@ function Invoke-Build
                 # --isolation 'hyperv' | makes sense on windows host only?
                 $buildOptions.Add("--isolation 'hyperv'")
             }
-            elseif ($IsolationModeBehaviour -ieq "ForceProcess") {
-                # --isolation 'process' | makes sense on all operating systems
+            elseif ($osType -ieq "windows" -and $IsolationModeBehaviour -ieq "ForceProcess") {
+                # --isolation 'process' | works only on windows
                 $buildOptions.Add("--isolation 'process'")
             }
+			elseif ($osType -ne "windows" -and $IsolationModeBehaviour -ieq "ForceDefault") {
+				# --isolation 'default' | works on non-windows
+				$buildOptions.Add("--isolation 'default'")
+			}
             else {
-                # no --isolation option | use engine default if none of the above (f.e. ForceHyperV on linux)
+                # no --isolation option | also use engine default if none of the above has been selected
             }
 
             $spec.BuildOptions | ForEach-Object {

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -201,11 +201,11 @@ function Invoke-Build
             # Build image
             $buildOptions = New-Object System.Collections.Generic.List[System.Object]
 
-            if ($osType -ieq "windows" -and $IsolationMode -ieq "ForceHyperV") {
+            if ($osType -ieq "windows" -and $IsolationModeBehaviour -ieq "ForceHyperV") {
                 # --isolation 'hyperv' | makes sense on windows host only?
                 $buildOptions.Add("--isolation 'hyperv'")
             }
-            elseif ($IsolationMode -ieq "ForceProcess") {
+            elseif ($IsolationModeBehaviour -ieq "ForceProcess") {
                 # --isolation 'process' | makes sense on all operating systems
                 $buildOptions.Add("--isolation 'process'")
             }


### PR DESCRIPTION
I was building the images on my local Windows 10 and on a Windows Server 2019.
Locally it worked fine, on the server it crashed during SQL Server image build.

It found this hard-coded `--isolation 'hyperv'` and replaced it with `--isolation 'process'` on the server and all issues went away.

I suggest to add a parameter 'IsolationMode' to allow the caller to either use default, hyperv or process isolation, depending on the OS and it's capabilities (see https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).