### PR TITLE
Add missing volume declaration for cd/cm containers

### DIFF
--- a/windows/tests/9.3.x/docker-compose.xm.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.jss.yml
@@ -25,6 +25,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -46,6 +48,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-jss-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.ps.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.ps.jss.yml
@@ -38,6 +38,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-ps-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -61,6 +63,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-ps-jss-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.ps.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.ps.yml
@@ -38,6 +38,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-ps-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -61,6 +63,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-ps-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.spe.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.spe.yml
@@ -25,6 +25,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -46,6 +48,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-spe-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.sxa.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.sxa.jss.yml
@@ -25,6 +25,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-sxa-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -47,6 +49,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-sxa-jss-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.sxa.ps.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.sxa.ps.jss.yml
@@ -38,6 +38,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-sxa-ps-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -62,6 +64,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-sxa-ps-jss-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.sxa.ps.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.sxa.ps.yml
@@ -38,6 +38,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-sxa-ps-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -62,6 +64,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-sxa-ps-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.sxa.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.sxa.yml
@@ -25,6 +25,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-sxa-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -47,6 +49,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-sxa-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xm.yml
+++ b/windows/tests/9.3.x/docker-compose.xm.yml
@@ -25,6 +25,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xm-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -46,6 +48,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xm-cm:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.jss.yml
@@ -108,6 +108,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -134,6 +136,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-jss-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.ps.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.ps.jss.yml
@@ -122,6 +122,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-ps-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -150,6 +152,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-ps-jss-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.ps.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.ps.yml
@@ -122,6 +122,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-ps-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -150,6 +152,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-ps-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.spe.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.spe.yml
@@ -108,6 +108,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -134,6 +136,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-spe-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.sxa.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.sxa.jss.yml
@@ -108,6 +108,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-sxa-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -135,6 +137,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-sxa-jss-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.sxa.ps.jss.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.sxa.ps.jss.yml
@@ -122,6 +122,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-sxa-ps-jss-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -151,6 +153,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-sxa-ps-jss-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.sxa.ps.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.sxa.ps.yml
@@ -122,6 +122,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-sxa-ps-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -151,6 +153,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-sxa-ps-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.sxa.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.sxa.yml
@@ -108,6 +108,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-sxa-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -135,6 +137,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-sxa-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:

--- a/windows/tests/9.3.x/docker-compose.xp.yml
+++ b/windows/tests/9.3.x/docker-compose.xp.yml
@@ -112,6 +112,8 @@ services:
   cd:
     image: ${REGISTRY}sitecore-xp-cd:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cd:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44002:80"
     environment:
@@ -138,6 +140,8 @@ services:
   cm:
     image: ${REGISTRY}sitecore-xp-standalone:${SITECORE_VERSION}-windowsservercore-${WINDOWSSERVERCORE_VERSION}
     entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    volumes:
+      - .\data\cm:C:\inetpub\wwwroot\App_Data\logs
     ports:
       - "44001:80"
     environment:


### PR DESCRIPTION
For some reason log volumes are not mapped for most of the CM/CD containers (all except commerce). Hope they have not been removed for purpose ;)

This PR restores CM/CD log volumes.