### PR TITLE
Enable HyperV Isolation to be disabled if required

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -34,7 +34,9 @@ param(
     [Parameter(HelpMessage = "If the docker image is already built it should be skipped.")]
     [switch]$SkipExistingImage,
     [Parameter()]
-    [switch]$IncludeExperimental
+    [switch]$IncludeExperimental,
+    [Parameter()]
+    [switch]$DisableHyperV
 )
 
 function Write-Message
@@ -237,7 +239,7 @@ SitecoreImageBuilder\Invoke-PackageRestore `
     -SitecorePassword $SitecorePassword `
     -Tags $tags `
     -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
-    -WhatIf:$WhatIfPreference
+    -WhatIf:$WhatIfPreference 
 
 # start the build
 SitecoreImageBuilder\Invoke-Build `
@@ -246,4 +248,5 @@ SitecoreImageBuilder\Invoke-Build `
     -Registry $Registry `
     -Tags $tags `
     -ExperimentalTagBehavior:(@{$true = "Include"; $false = "Skip" }[$IncludeExperimental -eq $true]) `
-    -WhatIf:$WhatIfPreference
+    -WhatIf:$WhatIfPreference `
+    -DisableHyperV:$DisableHyperV

--- a/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
+++ b/modules/SitecoreImageBuilder/1.0.0/Public/Invoke-Build.ps1
@@ -56,6 +56,9 @@ function Invoke-Build
         ,
         [Parameter(Mandatory = $false)]
         [switch]$SkipHashValidation
+        ,
+        [Parameter(Mandatory = $false)]
+        [switch]$DisableHyperV
     )
 
     # Setup
@@ -197,7 +200,7 @@ function Invoke-Build
             # Build image
             $buildOptions = New-Object System.Collections.Generic.List[System.Object]
 
-            if ($osType -eq "windows")
+            if ($osType -eq "windows" -and (-not $DisableHyperV))
             {
                 $buildOptions.Add("--isolation 'hyperv'")
             }


### PR DESCRIPTION
This PR adds a Disable HyperV flag, which enables build in environments without HyperV support.

For example, Azure Pipelines does not have HyperV isolation enabled in their hosted vs2019 containers. Running the supplied build script as is results in 

> Install-WindowsFeature : A prerequisite check for the Hyper-V feature failed.
   Hyper-V cannot be installed: The processor does not have required virtualization capabilities.

After removing the `--isolation 'hyperv'` flag from the `docker build` command the entire script is run successfully.

If this PR is merged, callers can now use 
`.\Build.ps1 -SitecoreUsername "YOUR dev.sitecore.net USERNAME" -SitecorePassword "YOUR dev.sitecore.net PASSWORD" -DisableHyperV`