### PR TITLE
Override Publishing Service RootUrl setting to fix publishing

### DIFF
--- a/windows/9.x.x/sitecore-ps-jss/Dockerfile
+++ b/windows/9.x.x/sitecore-ps-jss/Dockerfile
@@ -23,6 +23,9 @@ COPY --from=assets ["C:\\install\\tools\\", "C:\\install\\tools\\"]
 # find transform files and do transformation
 RUN (Get-ChildItem -Path 'C:\\inetpub\\wwwroot\\*.xdt' -Recurse ) | ForEach-Object { & 'C:\\install\\tools\\scripts\\Invoke-XdtTransform.ps1' -Path 'C:\\inetpub\\wwwroot\\web.config' -XdtPath $_.FullName -XdtDllPath 'C:\\install\\tools\\bin\\Microsoft.Web.XmlTransform.dll'; };
 
+# add config patches
+COPY .\config\*.config C:\\inetpub\\wwwroot\\App_Config\\Include\\
+
 FROM $BASE_IMAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/windows/9.x.x/sitecore-ps-jss/config/PublishingService.config
+++ b/windows/9.x.x/sitecore-ps-jss/config/PublishingService.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration xmlns:set="http://www.sitecore.net/xmlconfig/set/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+    <sitecore role:require="Standalone or ContentManagement">
+        <settings>
+            <setting name="PublishingService.UrlRoot" set:value="http://ps/"></setting>
+        </settings>
+    </sitecore>
+</configuration>

--- a/windows/9.x.x/sitecore-ps/Dockerfile
+++ b/windows/9.x.x/sitecore-ps/Dockerfile
@@ -21,6 +21,9 @@ COPY --from=assets ["C:\\install\\tools\\", "C:\\install\\tools\\"]
 # find transform files and do transformation
 RUN (Get-ChildItem -Path 'C:\\inetpub\\wwwroot\\*.xdt' -Recurse ) | ForEach-Object { & 'C:\\install\\tools\\scripts\\Invoke-XdtTransform.ps1' -Path 'C:\\inetpub\\wwwroot\\web.config' -XdtPath $_.FullName -XdtDllPath 'C:\\install\\tools\\bin\\Microsoft.Web.XmlTransform.dll'; }; 
 
+# add config patches
+COPY .\config\*.config C:\\inetpub\\wwwroot\\App_Config\\Include\\
+
 FROM $BASE_IMAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/windows/9.x.x/sitecore-ps/config/PublishingService.config
+++ b/windows/9.x.x/sitecore-ps/config/PublishingService.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration xmlns:set="http://www.sitecore.net/xmlconfig/set/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+    <sitecore role:require="Standalone or ContentManagement">
+        <settings>
+            <setting name="PublishingService.UrlRoot" set:value="http://ps/"></setting>
+        </settings>
+    </sitecore>
+</configuration>

--- a/windows/9.x.x/sitecore-sxa-ps-jss/Dockerfile
+++ b/windows/9.x.x/sitecore-sxa-ps-jss/Dockerfile
@@ -23,6 +23,9 @@ COPY --from=assets ["C:\\install\\tools\\", "C:\\install\\tools\\"]
 # find transform files and do transformation
 RUN (Get-ChildItem -Path 'C:\\inetpub\\wwwroot\\*.xdt' -Recurse ) | ForEach-Object { & 'C:\\install\\tools\\scripts\\Invoke-XdtTransform.ps1' -Path 'C:\\inetpub\\wwwroot\\web.config' -XdtPath $_.FullName -XdtDllPath 'C:\\install\\tools\\bin\\Microsoft.Web.XmlTransform.dll'; };
 
+# add config patches
+COPY .\config\*.config C:\\inetpub\\wwwroot\\App_Config\\Include\\
+
 FROM $BASE_IMAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/windows/9.x.x/sitecore-sxa-ps-jss/config/PublishingService.config
+++ b/windows/9.x.x/sitecore-sxa-ps-jss/config/PublishingService.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration xmlns:set="http://www.sitecore.net/xmlconfig/set/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+    <sitecore role:require="Standalone or ContentManagement">
+        <settings>
+            <setting name="PublishingService.UrlRoot" set:value="http://ps/"></setting>
+        </settings>
+    </sitecore>
+</configuration>

--- a/windows/9.x.x/sitecore-sxa-ps/Dockerfile
+++ b/windows/9.x.x/sitecore-sxa-ps/Dockerfile
@@ -21,6 +21,9 @@ COPY --from=assets ["C:\\install\\tools\\", "C:\\install\\tools\\"]
 # find transform files and do transformation
 RUN (Get-ChildItem -Path 'C:\\inetpub\\wwwroot\\*.xdt' -Recurse ) | ForEach-Object { & 'C:\\install\\tools\\scripts\\Invoke-XdtTransform.ps1' -Path 'C:\\inetpub\\wwwroot\\web.config' -XdtPath $_.FullName -XdtDllPath 'C:\\install\\tools\\bin\\Microsoft.Web.XmlTransform.dll'; }; 
 
+# add config patches
+COPY .\config\*.config C:\\inetpub\\wwwroot\\App_Config\\Include\\
+
 FROM $BASE_IMAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/windows/9.x.x/sitecore-sxa-ps/config/PublishingService.config
+++ b/windows/9.x.x/sitecore-sxa-ps/config/PublishingService.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration xmlns:set="http://www.sitecore.net/xmlconfig/set/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+    <sitecore role:require="Standalone or ContentManagement">
+        <settings>
+            <setting name="PublishingService.UrlRoot" set:value="http://ps/"></setting>
+        </settings>
+    </sitecore>
+</configuration>

--- a/windows/9.x.x/sitecore-xc-ps/Dockerfile
+++ b/windows/9.x.x/sitecore-xc-ps/Dockerfile
@@ -21,6 +21,9 @@ COPY --from=assets ["C:\\install\\tools\\", "C:\\install\\tools\\"]
 # find transform files and do transformation
 RUN (Get-ChildItem -Path 'C:\\inetpub\\wwwroot\\*.xdt' -Recurse ) | ForEach-Object { & 'C:\\install\\tools\\scripts\\Invoke-XdtTransform.ps1' -Path 'C:\\inetpub\\wwwroot\\web.config' -XdtPath $_.FullName -XdtDllPath 'C:\\install\\tools\\bin\\Microsoft.Web.XmlTransform.dll'; }; 
 
+# add config patches
+COPY .\config\*.config C:\\inetpub\\wwwroot\\App_Config\\Include\\
+
 FROM $BASE_IMAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/windows/9.x.x/sitecore-xc-ps/config/PublishingService.config
+++ b/windows/9.x.x/sitecore-xc-ps/config/PublishingService.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration xmlns:set="http://www.sitecore.net/xmlconfig/set/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+    <sitecore role:require="Standalone or ContentManagement">
+        <settings>
+            <setting name="PublishingService.UrlRoot" set:value="http://ps/"></setting>
+        </settings>
+    </sitecore>
+</configuration>


### PR DESCRIPTION
Override Publishing Service RootUrl setting as described in #208. Now Publishing Dashboard does not display errors, items delivered to `web`:

![image](https://user-images.githubusercontent.com/4719165/76936787-347ee480-68fc-11ea-90b5-fa92c62bcdd7.png)
