### PR TITLE
enable folder names different from src for watch dir task

### DIFF
--- a/windows/9.0.2/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.0.2/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.1.1/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.1.1/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.2.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.2.0/sitecore-assets/tools/entrypoints/sitecore-xc-engine/Development.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/entrypoints/sitecore-xc-engine/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.2.0/sitecore-assets/tools/entrypoints/xconnect/Development.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/entrypoints/xconnect/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/iis/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/sitecore-xc-engine/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/sitecore-xc-engine/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/worker/Development.ps1
@@ -14,7 +14,7 @@ Write-Host ("$(Get-Date -Format $timeFormat): Sitecore Development ENTRYPOINT, s
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {

--- a/windows/9.3.0/sitecore-assets/tools/entrypoints/xconnect/Development.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/entrypoints/xconnect/Development.ps1
@@ -103,7 +103,7 @@ else
 
 # check to see if we should start the Watch-Directory.ps1 script
 $watchDirectoryJobName = "Watch-Directory.ps1"
-$useWatchDirectory = (Test-Path -Path "C:\src" -PathType "Container") -eq $true
+$useWatchDirectory = $null -ne $WatchDirectoryParameters -bor (Test-Path -Path "C:\src" -PathType "Container") -eq $true
 
 if ($useWatchDirectory)
 {


### PR DESCRIPTION
allow watch dir task to start without having a symlink to c:/src (default was really made mandatory-ish).

personal opinion; default should not be .\src but rather .\publish or perhaps .\deploy - the folder name .\src infer source code dir by convention..