### PR TITLE
Watch-Directory.ps1 - deployment file sync issue fix

### DIFF
--- a/windows/9.0.2/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.0.2/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -100,21 +100,32 @@ $watcher.EnableRaisingEvents = $true
 
 Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageData $Destination {
     $destinationPath = Join-Path $event.MessageData $eventArgs.Name
-    $delete = !(Test-Path $eventArgs.FullPath) -and (Test-Path $destinationPath) -and !(Test-Path -Path $destinationPath -PathType "Container")
+    $delete = !(Test-Path $eventArgs.FullPath) -and (Test-Path $destinationPath)
 
     if ($delete)
     {
-        try
-        {
-            Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction "SilentlyContinue"
+        $retryAttempts = 300
+        $retryAttemptsCount = $retryAttempts
+        while ($retryAttemptsCount -gt 0) {
+            try
+            {
+                Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction Stop
+                Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
 
-            Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
-        }
-        catch
-        {
-            Write-Host ("{0}: Could not delete '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Red
+                $retryAttemptsCount = -1
+            }
+            catch
+            {
+                Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
+
+                $retryAttemptsCount--
+                Start-Sleep -Seconds 1
+            }
         }
 
+        if($retryAttemptsCount -eq 0) {
+            Write-Host ("{0}: Could not delete '{1}'... Retry attempts made: {2}. The file will NOT be deleted!" -f  [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $retryAttempts) -ForegroundColor Red
+        }
     }
 } | Out-Null
 

--- a/windows/9.0.2/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.0.2/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 5
+        $retryAttempts = 50
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try
@@ -119,7 +119,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
                 Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
 
                 $retryAttemptsCount--
-                Start-Sleep -Seconds 1
+                Start-Sleep -Milliseconds 100
             }
         }
 

--- a/windows/9.0.2/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.0.2/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 300
+        $retryAttempts = 5
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try

--- a/windows/9.1.1/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.1.1/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -100,21 +100,32 @@ $watcher.EnableRaisingEvents = $true
 
 Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageData $Destination {
     $destinationPath = Join-Path $event.MessageData $eventArgs.Name
-    $delete = !(Test-Path $eventArgs.FullPath) -and (Test-Path $destinationPath) -and !(Test-Path -Path $destinationPath -PathType "Container")
+    $delete = !(Test-Path $eventArgs.FullPath) -and (Test-Path $destinationPath)
 
     if ($delete)
     {
-        try
-        {
-            Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction "SilentlyContinue"
+        $retryAttempts = 300
+        $retryAttemptsCount = $retryAttempts
+        while ($retryAttemptsCount -gt 0) {
+            try
+            {
+                Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction Stop
+                Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
 
-            Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
-        }
-        catch
-        {
-            Write-Host ("{0}: Could not delete '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Red
+                $retryAttemptsCount = -1
+            }
+            catch
+            {
+                Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
+
+                $retryAttemptsCount--
+                Start-Sleep -Seconds 1
+            }
         }
 
+        if($retryAttemptsCount -eq 0) {
+            Write-Host ("{0}: Could not delete '{1}'... Retry attempts made: {2}. The file will NOT be deleted!" -f  [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $retryAttempts) -ForegroundColor Red
+        }
     }
 } | Out-Null
 

--- a/windows/9.1.1/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.1.1/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 5
+        $retryAttempts = 50
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try
@@ -119,7 +119,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
                 Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
 
                 $retryAttemptsCount--
-                Start-Sleep -Seconds 1
+                Start-Sleep -Milliseconds 100
             }
         }
 

--- a/windows/9.1.1/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.1.1/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 300
+        $retryAttempts = 5
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try

--- a/windows/9.2.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -100,21 +100,32 @@ $watcher.EnableRaisingEvents = $true
 
 Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageData $Destination {
     $destinationPath = Join-Path $event.MessageData $eventArgs.Name
-    $delete = !(Test-Path $eventArgs.FullPath) -and (Test-Path $destinationPath) -and !(Test-Path -Path $destinationPath -PathType "Container")
+    $delete = !(Test-Path $eventArgs.FullPath) -and (Test-Path $destinationPath)
 
     if ($delete)
     {
-        try
-        {
-            Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction "SilentlyContinue"
+        $retryAttempts = 300
+        $retryAttemptsCount = $retryAttempts
+        while ($retryAttemptsCount -gt 0) {
+            try
+            {
+                Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction Stop
+                Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
 
-            Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
-        }
-        catch
-        {
-            Write-Host ("{0}: Could not delete '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Red
+                $retryAttemptsCount = -1
+            }
+            catch
+            {
+                Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
+
+                $retryAttemptsCount--
+                Start-Sleep -Seconds 1
+            }
         }
 
+        if($retryAttemptsCount -eq 0) {
+            Write-Host ("{0}: Could not delete '{1}'... Retry attempts made: {2}. The file will NOT be deleted!" -f  [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $retryAttempts) -ForegroundColor Red
+        }
     }
 } | Out-Null
 

--- a/windows/9.2.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 5
+        $retryAttempts = 50
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try
@@ -119,7 +119,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
                 Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
 
                 $retryAttemptsCount--
-                Start-Sleep -Seconds 1
+                Start-Sleep -Milliseconds 100
             }
         }
 

--- a/windows/9.2.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.2.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 300
+        $retryAttempts = 5
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try

--- a/windows/9.3.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -2,11 +2,11 @@
 param(
     # Path to watch for changes
     [Parameter(Mandatory = $true)]
-    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})]
     [string]$Path,
     # Destination path to keep updated
     [Parameter(Mandatory = $true)]
-    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})]
     [string]$Destination,
     # Milliseconds to sleep between sync operations
     [Parameter(Mandatory = $false)]
@@ -39,9 +39,9 @@ function Sync
     )
 
     $command = @("robocopy", "`"$Path`"", "`"$Destination`"", "/E", "/XX", "/MT:1", "/NJH", "/NJS", "/FP", "/NDL", "/NP", "/NS", "/R:5", "/W:1")
-    
+
     if ($ExcludeDirectories.Count -gt 0)
-    {        
+    {
         $command += "/XD "
 
         $ExcludeDirectories | ForEach-Object {
@@ -52,7 +52,7 @@ function Sync
     }
 
     if ($ExcludeFiles.Count -gt 0)
-    {        
+    {
         $command += "/XF "
 
         $ExcludeFiles | ForEach-Object {
@@ -61,7 +61,7 @@ function Sync
 
         $command = $command.TrimEnd()
     }
-    
+
     $commandString = $command -join " "
 
     $dirty = $false
@@ -72,7 +72,7 @@ function Sync
 
         if ($dirty)
         {
-            Write-Host ("{0}: {1}" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $line) -ForegroundColor DarkGray            
+            Write-Host ("{0}: {1}" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $line) -ForegroundColor DarkGray
         }
     }
 
@@ -104,15 +104,27 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        try
-        {
-            Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction "SilentlyContinue"
+        $retryAttempts = 300
+        $retryAttemptsCount = $retryAttempts
+        while ($retryAttemptsCount -gt 0) {
+            try
+            {
+                Remove-Item -Path $destinationPath -Force -Recurse -ErrorAction Stop
+                Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
 
-            Write-Host ("{0}: Deleted '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Green
+                $retryAttemptsCount = -1
+            }
+            catch
+            {
+                Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
+
+                $retryAttemptsCount--
+                Start-Sleep -Seconds 1
+            }
         }
-        catch
-        {
-            Write-Host ("{0}: Could not delete '{1}'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath) -ForegroundColor Red
+
+        if($retryAttemptsCount -eq 0) {
+            Write-Host ("{0}: Could not delete '{1}'... Retry attempts made: {2}. The file will NOT be deleted!" -f  [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $retryAttempts) -ForegroundColor Red
         }
     }
 } | Out-Null
@@ -129,7 +141,7 @@ try
         Start-Sleep -Milliseconds $SleepMilliseconds
     }
 }
-finally 
+finally
 {
     # Cleanup
     Get-EventSubscriber -SourceIdentifier "FileDeleted" | Unregister-Event

--- a/windows/9.3.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 5
+        $retryAttempts = 50
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try
@@ -119,7 +119,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
                 Write-Host ("{0}: Could not delete '{1}'... `r`n'{2}'" -f [DateTime]::Now.ToString("HH:mm:ss:fff"), $destinationPath, $_.ToString()) -ForegroundColor DarkGray
 
                 $retryAttemptsCount--
-                Start-Sleep -Seconds 1
+                Start-Sleep -Milliseconds 100
             }
         }
 

--- a/windows/9.3.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
+++ b/windows/9.3.0/sitecore-assets/tools/scripts/Watch-Directory.ps1
@@ -104,7 +104,7 @@ Register-ObjectEvent $watcher Deleted -SourceIdentifier "FileDeleted" -MessageDa
 
     if ($delete)
     {
-        $retryAttempts = 300
+        $retryAttempts = 5
         $retryAttemptsCount = $retryAttempts
         while ($retryAttemptsCount -gt 0) {
             try


### PR DESCRIPTION
Fixes #306 
- Fixed Delete file event handler has issues:
 -- Corrected `ErrorAction` - set to `Stop` so that `Remove-Item` operation throws the error.
 -- Implemented retry mechanism - it will attempt to delete the file 300 times with 1 second waiting interval between attempts.