### PR TITLE
Update java version to LTS of openjdk

### DIFF
--- a/windows/dependencies/sitecore-openjdk/Dockerfile
+++ b/windows/dependencies/sitecore-openjdk/Dockerfile
@@ -7,8 +7,8 @@ FROM $BUILD_IMAGE as builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_HOME C:\\ojdkbuild
-ENV JAVA_OJDKBUILD_VERSION 1.8.0.191-1
-ENV JAVA_OJDKBUILD_ZIP java-1.8.0-openjdk-1.8.0.191-1.b12.ojdkbuild.windows.x86_64.zip
+ENV JAVA_OJDKBUILD_VERSION java-1.8.0-openjdk-1.8.0.252-2.b09
+ENV JAVA_OJDKBUILD_ZIP java-1.8.0-openjdk-1.8.0.252-2.b09.ojdkbuild.windows.x86_64.zip
 
 RUN New-Item -Path 'C:\\downloads' -ItemType 'Directory' -Force | Out-Null; `
     curl.exe -sS -L -o C:\\downloads\\ojdkbuild.zip  $('https://github.com/ojdkbuild/ojdkbuild/releases/download/{0}/{1}' -f $env:JAVA_OJDKBUILD_VERSION, $env:JAVA_OJDKBUILD_ZIP); `


### PR DESCRIPTION
OpenJDK Version in dockerfile has been removed from the openjdk github, and there for does not install when built.  Updated to latest LTS version so solr won't fail to start 

Recommend finding another way to get the latest supported version of things or check requisites available in the initial build scripts