### PR TITLE
Fixed Boot.ps1 scripts for SQL dev servers

### DIFF
--- a/legacy/images/9.0.2 rev. 180604/windowsservercore/sitecore-xp-sqldev/Boot.ps1
+++ b/legacy/images/9.0.2 rev. 180604/windowsservercore/sitecore-xp-sqldev/Boot.ps1
@@ -43,10 +43,10 @@ Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
 Write-Host "### Preparing Sitecore databases..."
 
 # See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
-Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $DatabasePrefix)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
 
 Write-Host "### Sitecore databases ready!"
 

--- a/legacy/images/9.1.0 rev. 001564/windowsservercore/sitecore-xp-sqldev/Boot.ps1
+++ b/legacy/images/9.1.0 rev. 001564/windowsservercore/sitecore-xp-sqldev/Boot.ps1
@@ -43,10 +43,10 @@ Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
 Write-Host "### Preparing Sitecore databases..."
 
 # See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
-Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $DatabasePrefix)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
 
 Write-Host "### Sitecore databases ready!"
 

--- a/legacy/images/9.1.1 rev. 002459/windowsservercore/sitecore-xp-sqldev/Boot.ps1
+++ b/legacy/images/9.1.1 rev. 002459/windowsservercore/sitecore-xp-sqldev/Boot.ps1
@@ -43,10 +43,10 @@ Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
 Write-Host "### Preparing Sitecore databases..."
 
 # See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
-Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $DatabasePrefix)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
 
 Write-Host "### Sitecore databases ready!"
 

--- a/legacy/images/9.2.0 rev. 002893/windowsservercore/sitecore-xp-sqldev/Boot.ps1
+++ b/legacy/images/9.2.0 rev. 002893/windowsservercore/sitecore-xp-sqldev/Boot.ps1
@@ -43,10 +43,10 @@ Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
 Write-Host "### Preparing Sitecore databases..."
 
 # See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
-Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $DatabasePrefix)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
 
 Write-Host "### Sitecore databases ready!"
 

--- a/windows/9.3.x/sitecore-xp-sqldev/Boot.ps1
+++ b/windows/9.3.x/sitecore-xp-sqldev/Boot.ps1
@@ -9,6 +9,9 @@ param(
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string]$SqlHostname
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DatabasePrefix = "Sitecore"
 )
 
 $timeFormat = "HH:mm:ss:fff"
@@ -64,9 +67,9 @@ Write-Host "$(Get-Date -Format $timeFormat): Preparing Sitecore databases..."
 
 # See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
 Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''Sitecore'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'")
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{0}'" -f $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{0}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{0}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}.Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}.Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}.Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
 
 Write-Host "$(Get-Date -Format $timeFormat): Sitecore databases ready!"
 

--- a/windows/9.x.x/sitecore-xp-sqldev/Boot.ps1
+++ b/windows/9.x.x/sitecore-xp-sqldev/Boot.ps1
@@ -9,6 +9,9 @@ param(
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string]$SqlHostname
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DatabasePrefix = "Sitecore"
 )
 
 $timeFormat = "HH:mm:ss:fff"
@@ -43,9 +46,9 @@ Write-Host "$(Get-Date -Format $timeFormat): Preparing Sitecore databases..."
 
 # See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
 Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''Sitecore'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'")
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{0}'" -f $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{0}'" -f $env:DB_PREFIX, $SqlHostname)
-Invoke-Sqlcmd -Query ("UPDATE [Sitecore.Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{0}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}.Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}.Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}.Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $DatabasePrefix, $SqlHostname)
 
 Write-Host "$(Get-Date -Format $timeFormat): Sitecore databases ready!"
 


### PR DESCRIPTION
Fixed wrong arguments for SQL query string formatting in `Boot.ps1` scripts.