### PR TITLE
correct opt path in linux boot.sh

### DIFF
--- a/linux/9.3.x/sitecore-xp-sql/boot.sh
+++ b/linux/9.3.x/sitecore-xp-sql/boot.sh
@@ -23,7 +23,7 @@ SQL_PID=$!
 
 echo "### SQL Server PID = '$SQL_PID'."
 
-./opt/attach-databases.sh $dataDir
+/opt/attach-databases.sh $dataDir
 
 # Pull sql server to foreground and support SIGTERM so shutdown works
 


### PR DESCRIPTION
we're copying all of the files into /opt but boot.sh refers to ./opt (which can be a different meaning if called from a different location)