### PR TITLE
Set ServerName xConnect shards on 9.3XP SQL linux images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## July 2020
 
+- [Bug] Sitecore 9.3.0 XP set ServerName xConnect shards on SQL linux images.
 - [Fixed] Sitecore 9.3.0 XP SQL Shard linux images.
 - [Added] Sitecore 9.3.0 XP/SXA/PS SQL linux images.
 - [Fixed] Sitecore 9.3.0 XP/SXA Solr linux images.

--- a/linux/9.3.x/sitecore-xp-sql/boot.sh
+++ b/linux/9.3.x/sitecore-xp-sql/boot.sh
@@ -25,6 +25,27 @@ echo "### SQL Server PID = '$SQL_PID'."
 
 /opt/attach-databases.sh $dataDir
 
+# set shard
+
+echo "### INIT XCONNECT = '$SQL_PID'."
+
+# to-do
+DatabasePrefix='Sitecore'
+
+/opt/mssql-tools/bin/sqlcmd -S . -U sa -P $SA_PASSWORD -t 120 -l 120 \
+-Q "EXEC sp_MSforeachdb 'IF charindex(''Sitecore'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'"
+
+/opt/mssql-tools/bin/sqlcmd -S . -U sa -P $SA_PASSWORD -t 120 -l 120 \
+-Q "UPDATE [$DatabasePrefix.Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '$SQL_HOSTNAME'"
+
+/opt/mssql-tools/bin/sqlcmd -S . -U sa -P $SA_PASSWORD -t 120 -l 120 \
+-Q "UPDATE [$DatabasePrefix.Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '$SQL_HOSTNAME'"
+
+/opt/mssql-tools/bin/sqlcmd -S . -U sa -P $SA_PASSWORD -t 120 -l 120 \
+-Q "UPDATE [$DatabasePrefix.Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '$SQL_HOSTNAME'"
+
+echo "### ENDING XCONNECT = '$SQL_PID'."
+
 # Pull sql server to foreground and support SIGTERM so shutdown works
 
 echo "### Bring SQLServer to foreground..."

--- a/linux/9.3.x/sitecore-xp-sql/boot.sh
+++ b/linux/9.3.x/sitecore-xp-sql/boot.sh
@@ -29,7 +29,6 @@ echo "### SQL Server PID = '$SQL_PID'."
 
 echo "### INIT XCONNECT = '$SQL_PID'."
 
-# to-do
 DatabasePrefix='Sitecore'
 
 /opt/mssql-tools/bin/sqlcmd -S . -U sa -P $SA_PASSWORD -t 120 -l 120 \


### PR DESCRIPTION
[Fix] set ServerName

![image](https://user-images.githubusercontent.com/116467/87548751-3e97d080-c6ad-11ea-9a98-92e2d3cb6908.png)
