### PR TITLE
Remove incompatible Solr schema parts from 9.1.1

### DIFF
--- a/windows/9.x.x/sitecore-xm-solr/managed-schema.default.911
+++ b/windows/9.x.x/sitecore-xm-solr/managed-schema.default.911
@@ -250,19 +250,6 @@
       <filter class="solr.SnowballPorterFilterFactory" language="Irish" />
     </analyzer>
   </fieldType>
-  <fieldType name="text_gen_sort" class="solr.SortableTextField" positionIncrementGap="100" multiValued="true">
-    <analyzer type="index">
-      <tokenizer class="solr.StandardTokenizerFactory" />
-      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true" />
-      <filter class="solr.LowerCaseFilterFactory" />
-    </analyzer>
-    <analyzer type="query">
-      <tokenizer class="solr.StandardTokenizerFactory" />
-      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true" />
-      <filter class="solr.SynonymGraphFilterFactory" expand="true" ignoreCase="true" synonyms="synonyms.txt" />
-      <filter class="solr.LowerCaseFilterFactory" />
-    </analyzer>
-  </fieldType>
   <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="false">
     <analyzer type="index">
       <tokenizer class="solr.StandardTokenizerFactory" />
@@ -349,14 +336,6 @@
       <filter class="solr.CJKWidthFilterFactory" />
       <filter class="solr.StopFilterFactory" words="lang/stopwords_ja.txt" ignoreCase="true" />
       <filter class="solr.JapaneseKatakanaStemFilterFactory" minimumLength="4" />
-      <filter class="solr.LowerCaseFilterFactory" />
-    </analyzer>
-  </fieldType>
-  <fieldType name="text_ko" class="solr.TextField" positionIncrementGap="100">
-    <analyzer>
-      <tokenizer class="solr.KoreanTokenizerFactory" outputUnknownUnigrams="false" decompoundMode="discard" />
-      <filter class="solr.KoreanPartOfSpeechStopFilterFactory" />
-      <filter class="solr.KoreanReadingFormFilterFactory" />
       <filter class="solr.LowerCaseFilterFactory" />
     </analyzer>
   </fieldType>

--- a/windows/9.x.x/sitecore-xp-solr/managed-schema.default.911
+++ b/windows/9.x.x/sitecore-xp-solr/managed-schema.default.911
@@ -250,19 +250,6 @@
       <filter class="solr.SnowballPorterFilterFactory" language="Irish" />
     </analyzer>
   </fieldType>
-  <fieldType name="text_gen_sort" class="solr.SortableTextField" positionIncrementGap="100" multiValued="true">
-    <analyzer type="index">
-      <tokenizer class="solr.StandardTokenizerFactory" />
-      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true" />
-      <filter class="solr.LowerCaseFilterFactory" />
-    </analyzer>
-    <analyzer type="query">
-      <tokenizer class="solr.StandardTokenizerFactory" />
-      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true" />
-      <filter class="solr.SynonymGraphFilterFactory" expand="true" ignoreCase="true" synonyms="synonyms.txt" />
-      <filter class="solr.LowerCaseFilterFactory" />
-    </analyzer>
-  </fieldType>
   <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="false">
     <analyzer type="index">
       <tokenizer class="solr.StandardTokenizerFactory" />
@@ -349,14 +336,6 @@
       <filter class="solr.CJKWidthFilterFactory" />
       <filter class="solr.StopFilterFactory" words="lang/stopwords_ja.txt" ignoreCase="true" />
       <filter class="solr.JapaneseKatakanaStemFilterFactory" minimumLength="4" />
-      <filter class="solr.LowerCaseFilterFactory" />
-    </analyzer>
-  </fieldType>
-  <fieldType name="text_ko" class="solr.TextField" positionIncrementGap="100">
-    <analyzer>
-      <tokenizer class="solr.KoreanTokenizerFactory" outputUnknownUnigrams="false" decompoundMode="discard" />
-      <filter class="solr.KoreanPartOfSpeechStopFilterFactory" />
-      <filter class="solr.KoreanReadingFormFilterFactory" />
       <filter class="solr.LowerCaseFilterFactory" />
     </analyzer>
   </fieldType>


### PR DESCRIPTION
Remove 9.1.1 schema parts that are not compatible with Solr 7.2.1.

Sortable text fields are available from Sorl 7.3 and Korean tokenizer factory are present from Solr 7.5.