### PR TITLE
Corrected .gitignore so that "/build/tools" are ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ windows/tests/**/data/**/*
 !windows/tests/**/data/*/.gitkeep
 
 /.vscode/
-/tools/
+/build/tools/
 
 windows/tests/**/mssql-data/**/*
 windows/tests/**/solr-data/**/*


### PR DESCRIPTION
Fix #365 