### PR TITLE
Change build pipeline agent to a self-hosted pool due to disk size limitation on Microsoft-hosted agents

### DIFF
--- a/build-images.yml
+++ b/build-images.yml
@@ -111,9 +111,10 @@ stages:
         displayName: "Build Linux Images"
         condition: eq(variables['build.linuxImages'], 'true')
         pool:
-          vmImage: 'ubuntu-18.04'
+          name: 'docker-linux-agents'
         steps:
           - task: Bash@3
+            displayName: "Connect to asset drive"
             condition: eq(variables['assets.useDrive'], 'true')
             inputs:
                 targetType: inline
@@ -143,6 +144,7 @@ stages:
           - checkout: self
             clean: true
           - powershell: |
+                sudo chmod 777 /mnt/dockerassets -R
                 "$(container.registry.password)" | docker login -u "$(container.registry.username)" --password-stdin $(container.registry.fullname)
                 $buildProps = @{
                   InstallSourcePath = "$(linux.install.source.path)"


### PR DESCRIPTION
Switching to a self-hosted linux pool since the Microsoft-hosted agents ran out of space on an xp1 build