### PR TITLE
Removing DevOps repo trigger

### DIFF
--- a/build-images.yml
+++ b/build-images.yml
@@ -173,35 +173,6 @@ stages:
           - powershell: |
                 docker image prune --force
             condition: and(succeeded(), eq(variables['build.pruneImages'], 'true'))
-  - stage: Trigger
-    dependsOn:
-    - Build_Windows_Images
-    - Build_Linux_Images
-    condition: and(succeeded('Build_Windows_Images'), succeeded('Build_Linux_Images'), ne(variables['build.triggerAdditionalBuild'], ''), eq(variables['Build.SourceBranch'], 'refs/heads/master') )
-    jobs:
-      - job: TriggerAdditionalBuild
-
-        displayName: "Trigger Additional Build"
-        steps:
-          - task: TriggerBuild@3
-            inputs:
-              definitionIsInCurrentTeamProject: true
-              buildDefinition: '$(build.triggerAdditionalBuild)'
-              queueBuildForUserThatTriggeredBuild: false
-              ignoreSslCertificateErrors: false
-              useSameSourceVersion: false
-              useCustomSourceVersion: false
-              useSameBranch: false
-              branchToUse: 'master'
-              waitForQueuedBuildsToFinish: false
-              storeInEnvironmentVariable: false
-              authenticationMethod: 'Personal Access Token'
-              password: '$(System.AccessToken)'
-              enableBuildInQueueCondition: false
-              dependentOnSuccessfulBuildCondition: false
-              dependentOnFailedBuildCondition: false
-              checkbuildsoncurrentbranch: false
-              failTaskIfConditionsAreNotFulfilled: false
   - stage: Trigger_Harbor_Push
     dependsOn:
     - Build_Windows_Images


### PR DESCRIPTION
Removed a stage that was used to trigger an additional repo build for the demo team. This build will now be triggered manually, as needed.