### PR TITLE
Adding the ability to output the 'will be built' images to Json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ windows/tests/**/data/**/*
 
 /.vscode/
 /build/tools/
+/build/docker-images.json
 
 windows/tests/**/mssql-data/**/*
 windows/tests/**/solr-data/**/*

--- a/Build.ps1
+++ b/Build.ps1
@@ -39,7 +39,10 @@ param(
     [switch]$IncludeExperimental,
     [Parameter(Mandatory = $false)]
     [ValidateSet("ForceHyperV", "EngineDefault", "ForceProcess", "ForceDefault")]
-    [string]$IsolationModeBehaviour = "ForceHyperV"
+    [string]$IsolationModeBehaviour = "ForceHyperV",
+    [Parameter(Mandatory = $false, HelpMessage = "If supplied, will output a 'docker-images.json' file in the working folder")]
+    [switch]
+    $OutputJson
 )
 
 Push-Location build
@@ -290,6 +293,13 @@ foreach ($wv in $OSVersion)
 }
 
 $tags = [System.Collections.ArrayList]@($tags | Select-Object -Unique)
+
+if ($tags -and $OutputJson)
+{
+    # if -OutputJson, send $tags for formatting and output to working folder
+    $json = Format-BuildOutputToJson $tags
+    $json | Set-Content -Path (Join-Path $PWD "docker-images.json") -Force
+}
 
 if ($SkipExistingImage)
 {

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## November 2020
+
+- [Added] Ability to provide `-OutputJson` switch to `build.ps1` to generate a Json file with a formatted list of images
+
 ## October 2020
 
 - [Added] JSS 15 images

--- a/build/modules/SitecoreImageBuilder/1.0.0/Public/Format-BuildOutputToJson.ps1
+++ b/build/modules/SitecoreImageBuilder/1.0.0/Public/Format-BuildOutputToJson.ps1
@@ -1,0 +1,25 @@
+function Format-BuildOutputToJson
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]] $Tags
+    )
+
+    $foundTags = @{}
+
+    foreach ($tag in $Tags)
+    {
+        $result = ($tag.Split(":")) # split the tag from the image name
+        if (-not $foundTags.ContainsKey($result[0]))
+        {
+            $foundTags.Add($result[0], [System.Collections.ArrayList]@($result[1]))
+        }
+        else
+        {
+            $foundTags[$result[0]] += $result[1]
+        }
+    }
+    $output = [PSCustomObject]$foundTags
+    return $output | ConvertTo-Json -Depth 3
+}

--- a/build/modules/SitecoreImageBuilder/1.0.0/SitecoreImageBuilder.psd1
+++ b/build/modules/SitecoreImageBuilder/1.0.0/SitecoreImageBuilder.psd1
@@ -58,7 +58,7 @@
     NestedModules          = @()
 
     # Functions to export from this module
-    FunctionsToExport      = @("Invoke-PackageRestore", "Invoke-Build", "Get-CurrentImagesMarkdown", "Get-BuildSpecifications", "Get-LatestSupportedVersion")
+    FunctionsToExport      = @("Invoke-PackageRestore", "Invoke-Build", "Get-CurrentImagesMarkdown", "Get-BuildSpecifications", "Get-LatestSupportedVersion", "Format-BuildOutputToJson")
 
     # Cmdlets to export from this module
     CmdletsToExport        = '*'


### PR DESCRIPTION
# Pull Request Checklist

## Image Details

- [ ] I have added NEW image tags
- [ ] I have made significant changes to existing images

<!--
Ensure you review the steps prior to submitting the pull request.
-->

## Pull Request Details

**What this PR does / why we need it**:

It is useful for other systems and automation to have output in a format that can be easily parsed. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

> Note the addition of `-OutputJson` to the command

```
.\Build.ps1 -InstallSourcePath C:\repository\ -SitecoreUsername j -SitecorePassword j -SitecoreVersion 10.0.0 -IncludeSpe -IncludeSxa -IncludeJss -IncludeSh -IncludeExperimental -OutputJson -OSVersion "1909","2004","ltsc2019"
```
## Pre-submit Checklist

- [x] I have read and am familiar with the contents of [CONTRIBUTING.md](https://github.com/Sitecore/docker-images/blob/master/CONTRIBUTING.md)
- [ ] I have built the images locally (all relevant OS versions, including Linux if applicable)

  - Include the `.\build.ps1` command used (don't forget to exclude your credentials!)
  - Ensure the build was done on a clean system (`docker system prune -af`)

- [ ] I have added or updated the necessary docker-compose file(s) in the `build/windows/tests` folder
- [ ] I have updated the documentation using `build\update-documentation.ps1`
- [x] I have updated the `build\CHANGELOG.md` with details about the change(s) included
