### PR TITLE
Adding ability to exclude asset images

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## November 2020
 
+- [Added] Ability to skip Module Asset Images with -SkipModuleAssets
 - [Added] Ability to provide `-OutputJson` switch to `build.ps1` to generate a Json file with a formatted list of images
 
 ## October 2020


### PR DESCRIPTION
# Pull Request Checklist

## Image Details

- [ ] I have added NEW image tags
- [ ] I have made significant changes to existing images

<!--
Ensure you review the steps prior to submitting the pull request.
-->

## Pull Request Details

**What this PR does / why we need it**:

Provides the ability to skip module asset images which are often not needed. This reduces the friction to getting up and running.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #458 by providing the ability to `-SkipModuleAssets`
Fixes #460 

**Special notes for your reviewer**:

Can be tested with

`.\Build.ps1 -InstallSourcePath C:\repository\ -SitecoreUsername j -SitecorePassword j -SitecoreVersion 10.0.0 -IncludeSpe -IncludeSxa -IncludeJss -IncludeSh -IncludeExperimental -SkipModuleAssets`

and

`.\Build.ps1 -InstallSourcePath C:\repository\ -SitecoreUsername j -SitecorePassword j -SitecoreVersion 10.0.0 -IncludeSpe -IncludeSxa -IncludeJss -IncludeSh -IncludeExperimental`

## Pre-submit Checklist

- [x] I have read and am familiar with the contents of [CONTRIBUTING.md](https://github.com/Sitecore/docker-images/blob/master/CONTRIBUTING.md)
- [x] I have built the images locally (all relevant OS versions, including Linux if applicable)

  - Include the `.\build.ps1` command used (don't forget to exclude your credentials!)
  - Ensure the build was done on a clean system (`docker system prune -af`)

- [ ] I have added or updated the necessary docker-compose file(s) in the `build/windows/tests` folder
- [ ] I have updated the documentation using `build\update-documentation.ps1`
- [x] I have updated the `build\CHANGELOG.md` with details about the change(s) included
