### PR TITLE
Add Coveo for Sitecore modules assets images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [//]: # "start: stats"
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](https://opensource.org/licenses/MIT) ![Repositories](https://img.shields.io/badge/Repositories-228-blue.svg?style=flat-square) ![Tags](https://img.shields.io/badge/Tags-1193-blue.svg?style=flat-square) ![Deprecated](https://img.shields.io/badge/Deprecated-0-lightgrey.svg?style=flat-square) ![Dockerfiles](https://img.shields.io/badge/Dockerfiles-111-blue.svg?style=flat-square) ![Default version](https://img.shields.io/badge/Default%20version-10.0.0%20on%20ltsc2019/1809-blue?style=flat-square)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](https://opensource.org/licenses/MIT) ![Repositories](https://img.shields.io/badge/Repositories-232-blue.svg?style=flat-square) ![Tags](https://img.shields.io/badge/Tags-1213-blue.svg?style=flat-square) ![Deprecated](https://img.shields.io/badge/Deprecated-0-lightgrey.svg?style=flat-square) ![Dockerfiles](https://img.shields.io/badge/Dockerfiles-111-blue.svg?style=flat-square) ![Default version](https://img.shields.io/badge/Default%20version-10.0.0%20on%20ltsc2019/1809-blue?style=flat-square)
 
 [//]: # "end: stats"
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## November 2020
 
 - [Added] Ability to provide `-OutputJson` switch to `build.ps1` to generate a Json file with a formatted list of images
+- [Added] Sitecore 10.0.0 community modules Linux/Windows Coveo for Sitecore and Coveo for Sitecore SXA 5.0.788.5 assets images
 
 ## October 2020
 

--- a/build/Download-Module-Prerequisites.ps1
+++ b/build/Download-Module-Prerequisites.ps1
@@ -35,7 +35,7 @@ $packages = @{"Sitecore Azure Toolkit 2.5.0-r02519.1061.zip"                    
     "Sitecore Connect for CMP XP for 10.0 v. 3.0.0 rev. 00134.zip"                                    = "https://dev.sitecore.net/~/media/8443DB808C834186B40D66D58499355B.ashx"
     "Sitecore Connect for CMP XM for 10.0 v. 3.0.0 rev. 00134.zip"                                    = "https://dev.sitecore.net/~/media/36489D794FA5489CBBB78653F03F81A3.ashx"
     "Sitecore Connect for Sitecore DAM-2.0.0.zip"                                                     = "https://dev.sitecore.net/~/media/7F118478CF78478087A1DB3EBDF9FBFE.ashx"
-    "Coveo for Sitecore SXA 10.0 5.0.822.2.zip"                                                       = "https://static.cloud.coveo.com/coveoforsitecore/packages/v5.0.822.2/Coveo%20for%20Sitecore%20SXA%2010.0%205.0.822.2.zip"
+    "Coveo for Sitecore SXA 10.0 5.0.788.5.zip"                                                       = "https://static.cloud.coveo.com/coveoforsitecore/packages/v5.0.788.5/Coveo%20for%20Sitecore%20SXA%2010.0%205.0.788.5.zip"
 }
 
 # download packages from Sitecore

--- a/build/Download-Module-Prerequisites.ps1
+++ b/build/Download-Module-Prerequisites.ps1
@@ -35,6 +35,7 @@ $packages = @{"Sitecore Azure Toolkit 2.5.0-r02519.1061.zip"                    
     "Sitecore Connect for CMP XP for 10.0 v. 3.0.0 rev. 00134.zip"                                    = "https://dev.sitecore.net/~/media/8443DB808C834186B40D66D58499355B.ashx"
     "Sitecore Connect for CMP XM for 10.0 v. 3.0.0 rev. 00134.zip"                                    = "https://dev.sitecore.net/~/media/36489D794FA5489CBBB78653F03F81A3.ashx"
     "Sitecore Connect for Sitecore DAM-2.0.0.zip"                                                     = "https://dev.sitecore.net/~/media/7F118478CF78478087A1DB3EBDF9FBFE.ashx"
+    "Coveo for Sitecore SXA 10.0 5.0.822.2.zip"                                                       = "https://static.cloud.coveo.com/coveoforsitecore/packages/v5.0.822.2/Coveo%20for%20Sitecore%20SXA%2010.0%205.0.822.2.zip"
 }
 
 # download packages from Sitecore

--- a/build/IMAGES.md
+++ b/build/IMAGES.md
@@ -1139,6 +1139,22 @@
 | 10.0.0 | community/modules/custom-dam-assets | 1809 |  | `community/modules/custom-dam-assets:10.0.0-1809` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-dam-assets | 2004 |  | `community/modules/custom-dam-assets:10.0.0-2004` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-dam-assets | 1909 |  | `community/modules/custom-dam-assets:10.0.0-1909` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-sxa-assets | 2004 |  | `community/modules/custom-coveo-sxa-assets:10.0.0-2004` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-sxa-assets | 1809 |  | `community/modules/custom-coveo-sxa-assets:10.0.0-1809` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-sxa-assets | 1903 |  | `community/modules/custom-coveo-sxa-assets:10.0.0-1903` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-sxa-assets | 1909 |  | `community/modules/custom-coveo-sxa-assets:10.0.0-1909` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-assets | 1909 |  | `community/modules/custom-coveo-assets:10.0.0-1909` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-assets | 2004 |  | `community/modules/custom-coveo-assets:10.0.0-2004` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-assets | 1903 |  | `community/modules/custom-coveo-assets:10.0.0-1903` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-assets | 1809 |  | `community/modules/custom-coveo-assets:10.0.0-1809` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-sxa-assets | 2004 |  | `community/modules/custom-coveo507885-sxa-assets:10.0.0-2004` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-sxa-assets | 1809 |  | `community/modules/custom-coveo507885-sxa-assets:10.0.0-1809` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-sxa-assets | 1903 |  | `community/modules/custom-coveo507885-sxa-assets:10.0.0-1903` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-sxa-assets | 1909 |  | `community/modules/custom-coveo507885-sxa-assets:10.0.0-1909` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-assets | 2004 |  | `community/modules/custom-coveo507885-assets:10.0.0-2004` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-assets | 1809 |  | `community/modules/custom-coveo507885-assets:10.0.0-1809` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-assets | 1903 |  | `community/modules/custom-coveo507885-assets:10.0.0-1903` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-assets | 1909 |  | `community/modules/custom-coveo507885-assets:10.0.0-1909` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-cmp-xp-assets | 2004 |  | `community/modules/custom-cmp-xp-assets:10.0.0-2004` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-cmp-xp-assets | 1809 |  | `community/modules/custom-cmp-xp-assets:10.0.0-1809` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-cmp-xp-assets | 1903 |  | `community/modules/custom-cmp-xp-assets:10.0.0-1903` [Dockerfile](windows/10.0.0/modules/Dockerfile) |
@@ -1215,6 +1231,10 @@
 | 10.0.0 | community/modules/custom-def-d365-assets | linux |  | `community/modules/custom-def-d365-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-def-assets | linux |  | `community/modules/custom-def-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-dam-assets | linux |  | `community/modules/custom-dam-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-sxa-assets | linux |  | `community/modules/custom-coveo-sxa-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo-assets | linux |  | `community/modules/custom-coveo-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-sxa-assets | linux |  | `community/modules/custom-coveo507885-sxa-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
+| 10.0.0 | community/modules/custom-coveo507885-assets | linux |  | `community/modules/custom-coveo507885-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-cmp-xp-assets | linux |  | `community/modules/custom-cmp-xp-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
 | 10.0.0 | community/modules/custom-cmp-xm-assets | linux |  | `community/modules/custom-cmp-xm-assets:10.0.0-linux` [Dockerfile](linux/10.0.0/modules/Dockerfile) |
 

--- a/build/INSTRUCTIONS.md
+++ b/build/INSTRUCTIONS.md
@@ -210,6 +210,8 @@ Experimental modules include, and are not limited to:
 - Sitecore Connect for Microsoft Dynamics 365 for Sales
 - Sitecore Connect for CMP
 - Sitecore Connect for Sitecore DAM
+- Coveo for Sitecore
+- Coveo for Sitecore SXA
 
 Azure Toolkit has also prerequisites, see (https://doc.sitecore.com/developers/sat/20/sitecore-azure-toolkit/en/getting-started-with-the-sitecore-azure-toolkit.html)
 

--- a/build/linux/10.0.0/modules/coveo-assets/build.json
+++ b/build/linux/10.0.0/modules/coveo-assets/build.json
@@ -1,0 +1,25 @@
+{
+  "tags": [
+    {
+      "tag": "community/modules/custom-coveo-assets:10.0.0-linux",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-alpine-3.10",
+        "--build-arg ROLES=cm",
+        "--file linux/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    },
+    {
+      "tag": "community/modules/custom-coveo507885-assets:10.0.0-linux",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-alpine-3.10",
+        "--build-arg ROLES=cm",
+        "--file linux/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    }
+  ],
+  "sources": [
+    "Coveo for Sitecore 10.0 5.0.788.5.scwdp.zip"
+  ]
+}

--- a/build/linux/10.0.0/modules/coveo-assets/tools/Extract-Resources.ps1
+++ b/build/linux/10.0.0/modules/coveo-assets/tools/Extract-Resources.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$Roles,
+    [Parameter(Mandatory=$true)]
+    [string]$SourceFolder,
+    [Parameter(Mandatory=$true)]
+    [string]$DestinationFolder
+)
+
+New-Item -Path $DestinationFolder -ItemType Directory -Force
+
+$Roles -Split ',' | ForEach-Object {
+    $role = $_
+
+    $sourceRoleFolder = Join-Path -Path $SourceFolder -ChildPath $role
+    $extractFolder = Join-Path -Path $sourceRoleFolder -ChildPath "temp"
+    $extractWebsiteFolder = Join-Path -Path $extractFolder -ChildPath "Content/Website"
+    $destinationRoleContentFolder = Join-Path -Path $DestinationFolder -ChildPath "$role/content"
+
+    $wdp = Get-ChildItem -Path $sourceRoleFolder -Filter *.scwdp.zip
+    Expand-Archive -Path $wdp.FullName -DestinationPath $extractFolder
+
+    New-Item -Path $destinationRoleContentFolder -ItemType Directory -Force
+    Move-Item -Path "$extractWebsiteFolder/*" -Destination $destinationRoleContentFolder -Force -ErrorAction SilentlyContinue
+
+    $dbs = Get-ChildItem -Path $extractFolder -Filter *.dacpac
+
+    if (($dbs | Measure-Object).Count -gt 0) {
+        $destinationDBFolder = Join-Path -Path $DestinationFolder -ChildPath "db"
+
+        if (!(Test-Path -Path $destinationDBFolder -PathType Container)) {
+            New-Item -Path $destinationDBFolder -ItemType Directory -Force
+        }
+
+        $dbs | ForEach-Object {
+            $db = $_
+
+            $destinationDBPath = Join-Path -Path $destinationDBFolder -ChildPath "Sitecore.$($db.Name)"
+            Move-Item -Path $_.FullName -Destination $destinationDBPath
+        }
+    }
+
+    $sourceSolrSchemaPath = Join-Path -Path $destinationRoleContentFolder -ChildPath "App_Data/SolrSchema/managed-schema"
+    if (Test-Path -Path $sourceSolrSchemaPath -PathType Leaf) {
+        $solrSchema = Get-Item -Path $sourceSolrSchemaPath
+        $destinationSolrSchemaFolder = Join-Path -Path $DestinationFolder -ChildPath "solr"
+
+        if (!(Test-Path -Path $destinationSolrSchemaFolder -PathType Container)) {
+            New-Item -Path $destinationSolrSchemaFolder -ItemType Directory -Force
+        }
+
+        Move-Item -Path $solrSchema.FullName -Destination $destinationSolrSchemaFolder
+    }
+}

--- a/build/linux/10.0.0/modules/coveo-sxa-assets/build.json
+++ b/build/linux/10.0.0/modules/coveo-sxa-assets/build.json
@@ -1,0 +1,25 @@
+{
+  "tags": [
+    {
+      "tag": "community/modules/custom-coveo-sxa-assets:10.0.0-linux",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-alpine-3.10",
+        "--build-arg ROLES=cm",
+        "--file linux/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    },
+    {
+      "tag": "community/modules/custom-coveo507885-sxa-assets:10.0.0-linux",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-alpine-3.10",
+        "--build-arg ROLES=cm",
+        "--file linux/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    }
+  ],
+  "sources": [
+    "Coveo for Sitecore SXA 10.0 5.0.788.5.scwdp.zip"
+  ]
+}

--- a/build/linux/10.0.0/modules/coveo-sxa-assets/tools/Extract-Resources.ps1
+++ b/build/linux/10.0.0/modules/coveo-sxa-assets/tools/Extract-Resources.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$Roles,
+    [Parameter(Mandatory=$true)]
+    [string]$SourceFolder,
+    [Parameter(Mandatory=$true)]
+    [string]$DestinationFolder
+)
+
+New-Item -Path $DestinationFolder -ItemType Directory -Force
+
+$Roles -Split ',' | ForEach-Object {
+    $role = $_
+
+    $sourceRoleFolder = Join-Path -Path $SourceFolder -ChildPath $role
+    $extractFolder = Join-Path -Path $sourceRoleFolder -ChildPath "temp"
+    $extractWebsiteFolder = Join-Path -Path $extractFolder -ChildPath "Content/Website"
+    $destinationRoleContentFolder = Join-Path -Path $DestinationFolder -ChildPath "$role/content"
+
+    $wdp = Get-ChildItem -Path $sourceRoleFolder -Filter *.scwdp.zip
+    Expand-Archive -Path $wdp.FullName -DestinationPath $extractFolder
+
+    New-Item -Path $destinationRoleContentFolder -ItemType Directory -Force
+    Move-Item -Path "$extractWebsiteFolder/*" -Destination $destinationRoleContentFolder -Force -ErrorAction SilentlyContinue
+
+    $dbs = Get-ChildItem -Path $extractFolder -Filter *.dacpac
+
+    if (($dbs | Measure-Object).Count -gt 0) {
+        $destinationDBFolder = Join-Path -Path $DestinationFolder -ChildPath "db"
+
+        if (!(Test-Path -Path $destinationDBFolder -PathType Container)) {
+            New-Item -Path $destinationDBFolder -ItemType Directory -Force
+        }
+
+        $dbs | ForEach-Object {
+            $db = $_
+
+            $destinationDBPath = Join-Path -Path $destinationDBFolder -ChildPath "Sitecore.$($db.Name)"
+            Move-Item -Path $_.FullName -Destination $destinationDBPath
+        }
+    }
+
+    $sourceSolrSchemaPath = Join-Path -Path $destinationRoleContentFolder -ChildPath "App_Data/SolrSchema/managed-schema"
+    if (Test-Path -Path $sourceSolrSchemaPath -PathType Leaf) {
+        $solrSchema = Get-Item -Path $sourceSolrSchemaPath
+        $destinationSolrSchemaFolder = Join-Path -Path $DestinationFolder -ChildPath "solr"
+
+        if (!(Test-Path -Path $destinationSolrSchemaFolder -PathType Container)) {
+            New-Item -Path $destinationSolrSchemaFolder -ItemType Directory -Force
+        }
+
+        Move-Item -Path $solrSchema.FullName -Destination $destinationSolrSchemaFolder
+    }
+}

--- a/build/sitecore-packages.json
+++ b/build/sitecore-packages.json
@@ -359,11 +359,11 @@
         "url": "https://github.com/Sitecore/xGenerator/releases/download/10.0.0/ExperienceGenerator_10.0.scwdp.zip",
         "hash": "F7E41060501D7BEFEA5D7C8E12F0D6EC06DED278884D1B96AC819F8A5A7B5A1A"
     },
-    "Coveo for Sitecore 10.0 5.0.822.2.scwdp.zip": {
-        "url": "https://static.cloud.coveo.com/coveoforsitecore/packages/v5.0.822.2/Coveo%20for%20Sitecore%2010.0%205.0.822.2.scwdp.zip",
-        "hash": "C6066C9024359D2008622B6E1465538BA7EE39EF3C221A01F6BE826AF071E325"
+    "Coveo for Sitecore 10.0 5.0.788.5.scwdp.zip": {
+        "url": "https://static.cloud.coveo.com/coveoforsitecore/packages/v5.0.788.5/Coveo%20for%20Sitecore%2010.0%205.0.788.5.scwdp.zip",
+        "hash": "6D6AC455F26887D4D6F3A82209AEAA06F58DDA1D46861C96D442F0ED4A9ACC03"
     },
-    "Coveo for Sitecore SXA 10.0 5.0.822.2.scwdp.zip": {
+    "Coveo for Sitecore SXA 10.0 5.0.788.5.scwdp.zip": {
         "url": "",
         "hash": ""
     }

--- a/build/sitecore-packages.json
+++ b/build/sitecore-packages.json
@@ -358,5 +358,13 @@
     "ExperienceGenerator_10.0.scwdp.zip": {
         "url": "https://github.com/Sitecore/xGenerator/releases/download/10.0.0/ExperienceGenerator_10.0.scwdp.zip",
         "hash": "F7E41060501D7BEFEA5D7C8E12F0D6EC06DED278884D1B96AC819F8A5A7B5A1A"
+    },
+    "Coveo for Sitecore 10.0 5.0.822.2.scwdp.zip": {
+        "url": "https://static.cloud.coveo.com/coveoforsitecore/packages/v5.0.822.2/Coveo%20for%20Sitecore%2010.0%205.0.822.2.scwdp.zip",
+        "hash": "C6066C9024359D2008622B6E1465538BA7EE39EF3C221A01F6BE826AF071E325"
+    },
+    "Coveo for Sitecore SXA 10.0 5.0.822.2.scwdp.zip": {
+        "url": "",
+        "hash": ""
     }
 }

--- a/build/windows/10.0.0/modules/coveo-assets/build.json
+++ b/build/windows/10.0.0/modules/coveo-assets/build.json
@@ -1,0 +1,29 @@
+{
+  "tags": [
+    {
+      "tag": "community/modules/custom-coveo-assets:10.0.0-${nanoserver_version}",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
+        "--build-arg TOOL_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.0.0-1809",
+        "--build-arg BASE_BUILD_IMAGE=mcr.microsoft.com/windows/servercore:${windowsservercore_version}",
+        "--build-arg ROLES=cm",
+        "--file windows/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    },
+    {
+      "tag": "community/modules/custom-coveo508222-assets:10.0.0-${nanoserver_version}",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
+        "--build-arg TOOL_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.0.0-1809",
+        "--build-arg BASE_BUILD_IMAGE=mcr.microsoft.com/windows/servercore:${windowsservercore_version}",
+        "--build-arg ROLES=cm",
+        "--file windows/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    }
+  ],
+  "sources": [
+    "Coveo for Sitecore 10.0 5.0.822.2.scwdp.zip"
+  ]
+}

--- a/build/windows/10.0.0/modules/coveo-assets/build.json
+++ b/build/windows/10.0.0/modules/coveo-assets/build.json
@@ -12,7 +12,7 @@
       "experimental": true
     },
     {
-      "tag": "community/modules/custom-coveo508222-assets:10.0.0-${nanoserver_version}",
+      "tag": "community/modules/custom-coveo507885-assets:10.0.0-${nanoserver_version}",
       "build-options": [
         "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
         "--build-arg TOOL_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.0.0-1809",
@@ -24,6 +24,6 @@
     }
   ],
   "sources": [
-    "Coveo for Sitecore 10.0 5.0.822.2.scwdp.zip"
+    "Coveo for Sitecore 10.0 5.0.788.5.scwdp.zip"
   ]
 }

--- a/build/windows/10.0.0/modules/coveo-assets/tools/Extract-Resources.ps1
+++ b/build/windows/10.0.0/modules/coveo-assets/tools/Extract-Resources.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$Roles,
+    [Parameter(Mandatory=$true)]
+    [string]$SourceFolder,
+    [Parameter(Mandatory=$true)]
+    [string]$DestinationFolder
+)
+
+New-Item -Path $DestinationFolder -ItemType Directory -Force
+
+$Roles -Split ',' | ForEach-Object {
+    $role = $_
+
+    $sourceRoleFolder = Join-Path -Path $SourceFolder -ChildPath $role
+    $extractFolder = Join-Path -Path $sourceRoleFolder -ChildPath "temp"
+    $extractWebsiteFolder = Join-Path -Path $extractFolder -ChildPath "Content\Website"
+    $destinationRoleContentFolder = Join-Path -Path $DestinationFolder -ChildPath "$role\content"
+
+    $wdp = Get-ChildItem -Path $sourceRoleFolder -Filter *.scwdp.zip
+    Expand-Archive -Path $wdp.FullName -DestinationPath $extractFolder
+
+    New-Item -Path $destinationRoleContentFolder -ItemType Directory -Force
+    Move-Item -Path "$extractWebsiteFolder\*" -Destination $destinationRoleContentFolder -Force -ErrorAction SilentlyContinue
+
+    $dbs = Get-ChildItem -Path $extractFolder -Filter *.dacpac
+
+    if (($dbs | Measure-Object).Count -gt 0) {
+        $destinationDBFolder = Join-Path -Path $DestinationFolder -ChildPath "db"
+
+        if (!(Test-Path -Path $destinationDBFolder -PathType Container)) {
+            New-Item -Path $destinationDBFolder -ItemType Directory -Force
+        }
+
+        $dbs | ForEach-Object {
+            $db = $_
+
+            $destinationDBPath = Join-Path -Path $destinationDBFolder -ChildPath "Sitecore.$($db.Name)"
+            Move-Item -Path $_.FullName -Destination $destinationDBPath
+        }
+    }
+
+    $sourceSolrSchemaPath = Join-Path -Path $destinationRoleContentFolder -ChildPath "App_Data\SolrSchema\managed-schema"
+    if (Test-Path -Path $sourceSolrSchemaPath -PathType Leaf) {
+        $solrSchema = Get-Item -Path $sourceSolrSchemaPath
+        $destinationSolrSchemaFolder = Join-Path -Path $DestinationFolder -ChildPath "solr"
+
+        if (!(Test-Path -Path $destinationSolrSchemaFolder -PathType Container)) {
+            New-Item -Path $destinationSolrSchemaFolder -ItemType Directory -Force
+        }
+
+        Move-Item -Path $solrSchema.FullName -Destination $destinationSolrSchemaFolder
+    }
+}

--- a/build/windows/10.0.0/modules/coveo-sxa-assets/build.json
+++ b/build/windows/10.0.0/modules/coveo-sxa-assets/build.json
@@ -12,7 +12,7 @@
       "experimental": true
     },
     {
-      "tag": "community/modules/custom-coveo508222-sxa-assets:10.0.0-${nanoserver_version}",
+      "tag": "community/modules/custom-coveo507885-sxa-assets:10.0.0-${nanoserver_version}",
       "build-options": [
         "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
         "--build-arg TOOL_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.0.0-1809",
@@ -24,6 +24,6 @@
     }
   ],
   "sources": [
-    "Coveo for Sitecore SXA 10.0 5.0.822.2.scwdp.zip"
+    "Coveo for Sitecore SXA 10.0 5.0.788.5.scwdp.zip"
   ]
 }

--- a/build/windows/10.0.0/modules/coveo-sxa-assets/build.json
+++ b/build/windows/10.0.0/modules/coveo-sxa-assets/build.json
@@ -1,0 +1,29 @@
+{
+  "tags": [
+    {
+      "tag": "community/modules/custom-coveo-sxa-assets:10.0.0-${nanoserver_version}",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
+        "--build-arg TOOL_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.0.0-1809",
+        "--build-arg BASE_BUILD_IMAGE=mcr.microsoft.com/windows/servercore:${windowsservercore_version}",
+        "--build-arg ROLES=cm",
+        "--file windows/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    },
+    {
+      "tag": "community/modules/custom-coveo508222-sxa-assets:10.0.0-${nanoserver_version}",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
+        "--build-arg TOOL_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.0.0-1809",
+        "--build-arg BASE_BUILD_IMAGE=mcr.microsoft.com/windows/servercore:${windowsservercore_version}",
+        "--build-arg ROLES=cm",
+        "--file windows/10.0.0/modules/Dockerfile"
+      ],
+      "experimental": true
+    }
+  ],
+  "sources": [
+    "Coveo for Sitecore SXA 10.0 5.0.822.2.scwdp.zip"
+  ]
+}

--- a/build/windows/10.0.0/modules/coveo-sxa-assets/tools/Extract-Resources.ps1
+++ b/build/windows/10.0.0/modules/coveo-sxa-assets/tools/Extract-Resources.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$Roles,
+    [Parameter(Mandatory=$true)]
+    [string]$SourceFolder,
+    [Parameter(Mandatory=$true)]
+    [string]$DestinationFolder
+)
+
+New-Item -Path $DestinationFolder -ItemType Directory -Force
+
+$Roles -Split ',' | ForEach-Object {
+    $role = $_
+
+    $sourceRoleFolder = Join-Path -Path $SourceFolder -ChildPath $role
+    $extractFolder = Join-Path -Path $sourceRoleFolder -ChildPath "temp"
+    $extractWebsiteFolder = Join-Path -Path $extractFolder -ChildPath "Content\Website"
+    $destinationRoleContentFolder = Join-Path -Path $DestinationFolder -ChildPath "$role\content"
+
+    $wdp = Get-ChildItem -Path $sourceRoleFolder -Filter *.scwdp.zip
+    Expand-Archive -Path $wdp.FullName -DestinationPath $extractFolder
+
+    New-Item -Path $destinationRoleContentFolder -ItemType Directory -Force
+    Move-Item -Path "$extractWebsiteFolder\*" -Destination $destinationRoleContentFolder -Force -ErrorAction SilentlyContinue
+
+    $dbs = Get-ChildItem -Path $extractFolder -Filter *.dacpac
+
+    if (($dbs | Measure-Object).Count -gt 0) {
+        $destinationDBFolder = Join-Path -Path $DestinationFolder -ChildPath "db"
+
+        if (!(Test-Path -Path $destinationDBFolder -PathType Container)) {
+            New-Item -Path $destinationDBFolder -ItemType Directory -Force
+        }
+
+        $dbs | ForEach-Object {
+            $db = $_
+
+            $destinationDBPath = Join-Path -Path $destinationDBFolder -ChildPath "Sitecore.$($db.Name)"
+            Move-Item -Path $_.FullName -Destination $destinationDBPath
+        }
+    }
+
+    $sourceSolrSchemaPath = Join-Path -Path $destinationRoleContentFolder -ChildPath "App_Data\SolrSchema\managed-schema"
+    if (Test-Path -Path $sourceSolrSchemaPath -PathType Leaf) {
+        $solrSchema = Get-Item -Path $sourceSolrSchemaPath
+        $destinationSolrSchemaFolder = Join-Path -Path $DestinationFolder -ChildPath "solr"
+
+        if (!(Test-Path -Path $destinationSolrSchemaFolder -PathType Container)) {
+            New-Item -Path $destinationSolrSchemaFolder -ItemType Directory -Force
+        }
+
+        Move-Item -Path $solrSchema.FullName -Destination $destinationSolrSchemaFolder
+    }
+}


### PR DESCRIPTION
# Pull Request Checklist

## Image Details

- [x] I have added NEW image tags
- [ ] I have made significant changes to existing images

## Pull Request Details

**What this PR does / why we need it**: Added Coveo for Sitecore and Coveo for Sitecore SXA modules assets images. Coveo for Sitecore version is 5.0.788.5 (September 2020 release) compatible with Sitecore 10.0. For each module, there is an image that will be updated with the latest release and an image for the specific Coveo for Sitecore release. similar to JSS 14.0 and 15.0.

## Pre-submit Checklist

- [x] I have read and am familiar with the contents of [CONTRIBUTING.md](https://github.com/Sitecore/docker-images/blob/master/CONTRIBUTING.md)
- [x] I have built the images locally (all relevant OS versions, including Linux if applicable)
  - `.\Build.ps1 -SitecoreUsername $myusername -SitecorePassword $mypassword -IncludeExperimental`
  - `.\Build.ps1 -SitecoreUsername $myusername -SitecorePassword $mypassword -IncludeExperimental -OSVersion Linux`
- [ ] I have added or updated the necessary docker-compose file(s) in the `build/windows/tests` folder
- [x] I have updated the documentation using `build\update-documentation.ps1`
- [x] I have updated the `build\CHANGELOG.md` with details about the change(s) included
