### PR TITLE
Redirecting instructions to official documentation

### DIFF
--- a/build/INSTRUCTIONS.md
+++ b/build/INSTRUCTIONS.md
@@ -3,7 +3,7 @@
 
 These instructions will help you understand how to **build custom images** derived from the official Sitecore v10 images as well as how to build full Sitecore images using legacy (pre v10) assets.
 
-For detailed documentation on how to get started running Sitecore version 10 or above in a containerized environment, please see the [official documentation](https://containers.doc.sitecore.com/docs/intro)
+> **For detailed documentation on how to get started running Sitecore version 10 or above in a containerized environment, please see the [official documentation](https://containers.doc.sitecore.com/docs/intro)**
 
 ## Tagging and Windows versions
 

--- a/build/INSTRUCTIONS.md
+++ b/build/INSTRUCTIONS.md
@@ -1,7 +1,9 @@
 
 # How to use
 
-These instructions will help you understand how to build custom images derived from the official Sitecore v10 images as well as how to build full Sitecore images using legacy (pre v10) assets.
+These instructions will help you understand how to **build custom images** derived from the official Sitecore v10 images as well as how to build full Sitecore images using legacy (pre v10) assets.
+
+For detailed documentation on how to get started running Sitecore version 10 or above in a containerized environment, please see the [official documentation](https://containers.doc.sitecore.com/docs/intro)
 
 ## Tagging and Windows versions
 


### PR DESCRIPTION
To decrease the learning curve and confusion, added a note at the top of INSTRUCTIONS.md suggesting users visit the official documentation site for getting started.

