### PR TITLE
Adding a 10.0.1 version of tools assets

### DIFF
--- a/build/windows/10.0.x/sitecore-docker-tools-assets/build.json
+++ b/build/windows/10.0.x/sitecore-docker-tools-assets/build.json
@@ -6,8 +6,14 @@
         "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
         "--build-arg TOOL_IMAGE=${sitecore_registry}/tools/sitecore-docker-tools-assets:10.0.0-1809"
       ]
+    },
+    {
+      "tag": "community/modules/custom-sitecore-docker-tools-assets:10.0.1-${nanoserver_version}",
+      "build-options": [
+        "--build-arg BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:${nanoserver_version}",
+        "--build-arg TOOL_IMAGE=${sitecore_registry}/tools/sitecore-docker-tools-assets:10.0.0-1809"
+      ]
     }
   ],
-  "sources": [
-  ]
+  "sources": []
 }


### PR DESCRIPTION
to simplify the build process, adding a 10.0.1 version of the sitecore-docker-tools-assets image, similar to how other module asset images also got tagged with 10.0.1