### PR TITLE
Missing JSS 15.0.1 tag for Linux mssql roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [//]: # "start: stats"
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](https://opensource.org/licenses/MIT) ![Repositories](https://img.shields.io/badge/Repositories-261-blue.svg?style=flat-square) ![Tags](https://img.shields.io/badge/Tags-2324-blue.svg?style=flat-square) ![Deprecated](https://img.shields.io/badge/Deprecated-0-lightgrey.svg?style=flat-square) ![Dockerfiles](https://img.shields.io/badge/Dockerfiles-129-blue.svg?style=flat-square) ![Default version](https://img.shields.io/badge/Default%20version-10.0.0%20on%20ltsc2019/1809-blue?style=flat-square)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](https://opensource.org/licenses/MIT) ![Repositories](https://img.shields.io/badge/Repositories-261-blue.svg?style=flat-square) ![Tags](https://img.shields.io/badge/Tags-2328-blue.svg?style=flat-square) ![Deprecated](https://img.shields.io/badge/Deprecated-0-lightgrey.svg?style=flat-square) ![Dockerfiles](https://img.shields.io/badge/Dockerfiles-129-blue.svg?style=flat-square) ![Default version](https://img.shields.io/badge/Default%20version-10.0.0%20on%20ltsc2019/1809-blue?style=flat-square)
 
 [//]: # "end: stats"
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
+## January 2021
+
+- [Changed] Removed -Property FullName from Get-Item "C:\Program Files\Microsoft SQL Server\*\DAC\bin\SqlPackage.exe" | Select-Object -Last 1 -ExpandProperty FullName.
+- [Changed] Collapsed 10.x.x folders into version-specific to greatly improve upgradability. Added build\New-SitecoreVersion.ps1 script.
+- [Added] Missing JSS 15.0.1 Linux images
+
 ## December 2020
+
 - [Added] Sitecore JSS v15.0.1 See [#474](https://github.com/Sitecore/docker-images/issues/474). Thanks [@vtml](https://github.com/vtml) :+1:
 - [Added] re-tagged versions of sitecore-docker-tools-assets (now called custom-sitecore-docker-tools-assets)
 - [Changed] Download-Module-Prerequisites.ps1 to use new CDN urls and no longer require username/password
@@ -12,8 +19,6 @@
 - [Added] Sitecore 10.0.1 community modules Linux/Windows Coveo for Sitecore and Coveo for Sitecore SXA 5.0.858.1 assets images
 - [Added] Global Downloads Support
 - [Changed] Removed username/password from documentation. Fixed Test-SitecorePackages and sorted packages.
-- [Changed] Removed -Property FullName from Get-Item "C:\Program Files\Microsoft SQL Server\*\DAC\bin\SqlPackage.exe" | Select-Object -Last 1 -ExpandProperty FullName.
-- [Changed] Collapsed 10.x.x folders into version-specific to greatly improve upgradability. Added build\New-SitecoreVersion.ps1 script.
 
 ## November 2020
 

--- a/build/IMAGES.md
+++ b/build/IMAGES.md
@@ -2258,6 +2258,8 @@
 | 10.0.1 | community/sitecore-xp1-custom-sxa-mssql | linux |  | `community/sitecore-xp1-custom-sxa-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp1-custom-sxa-jss-ps-mssql | linux |  | `community/sitecore-xp1-custom-sxa-jss-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp1-custom-sxa-jss-mssql | linux |  | `community/sitecore-xp1-custom-sxa-jss-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
+| 10.0.1 | community/sitecore-xp1-custom-sxa-jss1501-ps-mssql | linux |  | `community/sitecore-xp1-custom-sxa-jss1501-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
+| 10.0.1 | community/sitecore-xp1-custom-sxa-jss1501-mssql | linux |  | `community/sitecore-xp1-custom-sxa-jss1501-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp1-custom-sxa-jss1500-ps-mssql | linux |  | `community/sitecore-xp1-custom-sxa-jss1500-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp1-custom-sxa-jss1500-mssql | linux |  | `community/sitecore-xp1-custom-sxa-jss1500-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp1-custom-sxa-jss1400-ps-mssql | linux |  | `community/sitecore-xp1-custom-sxa-jss1400-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
@@ -2269,6 +2271,8 @@
 | 10.0.1 | community/sitecore-xp0-custom-sxa-mssql | linux |  | `community/sitecore-xp0-custom-sxa-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp0-custom-sxa-jss-ps-mssql | linux |  | `community/sitecore-xp0-custom-sxa-jss-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp0-custom-sxa-jss-mssql | linux |  | `community/sitecore-xp0-custom-sxa-jss-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
+| 10.0.1 | community/sitecore-xp0-custom-sxa-jss1501-ps-mssql | linux |  | `community/sitecore-xp0-custom-sxa-jss1501-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
+| 10.0.1 | community/sitecore-xp0-custom-sxa-jss1501-mssql | linux |  | `community/sitecore-xp0-custom-sxa-jss1501-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp0-custom-sxa-jss1500-ps-mssql | linux |  | `community/sitecore-xp0-custom-sxa-jss1500-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp0-custom-sxa-jss1500-mssql | linux |  | `community/sitecore-xp0-custom-sxa-jss1500-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |
 | 10.0.1 | community/sitecore-xp0-custom-sxa-jss1400-ps-mssql | linux |  | `community/sitecore-xp0-custom-sxa-jss1400-ps-mssql:10.0.1-linux` [Dockerfile](linux/10.0.1/sitecore-roles/sitecore-modules-mssql/Dockerfile) |

--- a/build/linux/10.0.1/sitecore-roles/sitecore-modules-mssql/xp0-build.json
+++ b/build/linux/10.0.1/sitecore-roles/sitecore-modules-mssql/xp0-build.json
@@ -41,6 +41,14 @@
       ]
     },
     {
+      "tag": "community/sitecore-xp0-custom-sxa-jss1501-mssql:10.0.1-linux",
+      "build-options": [
+        "--memory 4GB",
+        "--build-arg BASE_IMAGE=community/sitecore-xp0-custom-sxa-mssql:10.0.1-linux",
+        "--build-arg MODULE_ASSETS=community/modules/custom-jss1501-xp-assets:10.0.1-linux"
+      ]
+    },
+    {
       "tag": "community/sitecore-xp0-custom-spe-ps-mssql:10.0.1-linux",
       "build-options": [
         "--memory 4GB",
@@ -77,6 +85,14 @@
       "build-options": [
         "--memory 4GB",
         "--build-arg BASE_IMAGE=community/sitecore-xp0-custom-sxa-jss1500-mssql:10.0.1-linux",
+        "--build-arg MODULE_ASSETS=community/modules/custom-ps-assets:10.0.1-linux"
+      ]
+    },
+    {
+      "tag": "community/sitecore-xp0-custom-sxa-jss1501-ps-mssql:10.0.1-linux",
+      "build-options": [
+        "--memory 4GB",
+        "--build-arg BASE_IMAGE=community/sitecore-xp0-custom-sxa-jss1501-mssql:10.0.1-linux",
         "--build-arg MODULE_ASSETS=community/modules/custom-ps-assets:10.0.1-linux"
       ]
     }

--- a/build/linux/10.0.1/sitecore-roles/sitecore-modules-mssql/xp1-build.json
+++ b/build/linux/10.0.1/sitecore-roles/sitecore-modules-mssql/xp1-build.json
@@ -33,6 +33,14 @@
       ]
     },
     {
+      "tag": "community/sitecore-xp1-custom-sxa-jss1501-mssql:10.0.1-linux",
+      "build-options": [
+        "--memory 4GB",
+        "--build-arg BASE_IMAGE=community/sitecore-xp1-custom-sxa-mssql:10.0.1-linux",
+        "--build-arg MODULE_ASSETS=community/modules/custom-jss1501-xp-assets:10.0.1-linux"
+      ]
+    },
+    {
       "tag": "community/sitecore-xp1-custom-sxa-jss1400-mssql:10.0.1-linux",
       "build-options": [
         "--memory 4GB",
@@ -69,6 +77,14 @@
       "build-options": [
         "--memory 4GB",
         "--build-arg BASE_IMAGE=community/sitecore-xp1-custom-sxa-jss1500-mssql:10.0.1-linux",
+        "--build-arg MODULE_ASSETS=community/modules/custom-ps-assets:10.0.1-linux"
+      ]
+    },
+    {
+      "tag": "community/sitecore-xp1-custom-sxa-jss1501-ps-mssql:10.0.1-linux",
+      "build-options": [
+        "--memory 4GB",
+        "--build-arg BASE_IMAGE=community/sitecore-xp1-custom-sxa-jss1501-mssql:10.0.1-linux",
         "--build-arg MODULE_ASSETS=community/modules/custom-ps-assets:10.0.1-linux"
       ]
     },


### PR DESCRIPTION
# Pull Request Checklist

## Image Details

- [x] I have added NEW image tags
- [ ] I have made significant changes to existing images

## Pull Request Details

**What this PR does / why we need it**:
Missing a few linux JSS 15.0.1 tags

## Pre-submit Checklist

- [x] I have read and am familiar with the contents of [CONTRIBUTING.md](https://github.com/Sitecore/docker-images/blob/master/CONTRIBUTING.md)
- [x] I have built the images locally (all relevant OS versions, including Linux if applicable)

  - Include the `.\build.ps1` command used (don't forget to exclude your credentials!)
  - Ensure the build was done on a clean system (`docker system prune -af`)

- [ ] I have added or updated the necessary docker-compose file(s) in the `build/windows/tests` folder
- [x] I have updated the documentation using `build\update-documentation.ps1`
- [x] I have updated the `build\CHANGELOG.md` with details about the change(s) included
