### PR TITLE
Defect/build script filters

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -98,7 +98,8 @@ filter WindowsFilter {
 filter SitecoreFilter {
     param([string]$Version)
 
-    if ($_.Tag -like "*$Version*") {
+    # Sitecore 10.x is picked up via Path, 9.x is picked up via Tag
+    if ($_.Path -like "*$Version*" -or $_.Tag -like "*$Version*") {
         $_
     }
 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -98,7 +98,7 @@ filter WindowsFilter {
 filter SitecoreFilter {
     param([string]$Version)
 
-    if ($_.Path -like "*$Version*") {
+    if ($_.Tag -like "*$Version*") {
         $_
     }
 }

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Added] PublishModuleAssetsOnly parameter (if 'true', Build.ps1 will exit after publishing module assets)
 - [Added] LinuxBuildAssetPath parameter
 - [Changed] 'SkipModuleAssets' parameter was replaced with 'IncludeModuleAssets'
+- [Fixed] SitecoreFilter was filtering based on Path; now filters based on Tag
 
 ## January 2021
 


### PR DESCRIPTION
Some `Path` values contain .x.x (e.g. 9.x.x) instead of the full Sitecore Version value (e.g. `9.3.0`). As a result, they are not being included in the list of images to be built when using specifies their `SitecoreVersion` value.

# Pull Request Checklist

## Image Details

- [ ] I have added NEW image tags
- [ ] I have made significant changes to existing images

<!--
Ensure you review the steps prior to submitting the pull request.
-->

## Pull Request Details

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

## Pre-submit Checklist

- [x] I have read and am familiar with the contents of [CONTRIBUTING.md](https://github.com/Sitecore/docker-images/blob/master/CONTRIBUTING.md)
- [x] I have built the images locally (all relevant OS versions, including Linux if applicable)

  - Include the `.\build.ps1` command used (don't forget to exclude your credentials!)
  - Ensure the build was done on a clean system (`docker system prune -af`)

- [ ] I have added or updated the necessary docker-compose file(s) in the `build/windows/tests` folder
- [x] I have updated the documentation using `build\update-documentation.ps1`
- [x] I have updated the `build\CHANGELOG.md` with details about the change(s) included
