### PR TITLE
Cannot build Linux sql images for Sitecore version 9.2

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## December 2021
+
+- [Changed] Updated url for SQL Server on Linux Sitecore 9.2 images
+
 ## May 2021
 
 - [Added] Sitecore 10.1.0 XM1 Linux SQL Images

--- a/build/linux/9.2.0/sitecore-xm-sql/Dockerfile
+++ b/build/linux/9.2.0/sitecore-xm-sql/Dockerfile
@@ -4,7 +4,7 @@ FROM $BASE_IMAGE as builder
 
 RUN apt-get -y update \
     && apt-get -y --allow-unauthenticated install unzip \ 
-    && wget -progress=bar:force -q -O sqlpackage.zip https://go.microsoft.com/fwlink/?linkid=2087431 \
+    && wget -progress=bar:force -q -O sqlpackage.zip https://go.microsoft.com/fwlink/?linkid=2113331 \
     && unzip -qq sqlpackage.zip -d /opt/sqlpackage \
     && chmod +x /opt/sqlpackage/sqlpackage
 

--- a/build/linux/9.2.0/sitecore-xp-sql/Dockerfile
+++ b/build/linux/9.2.0/sitecore-xp-sql/Dockerfile
@@ -4,7 +4,7 @@ FROM $BASE_IMAGE as builder
 
 RUN apt-get -y update \
     && apt-get -y --allow-unauthenticated install unzip \ 
-    && wget -progress=bar:force -q -O sqlpackage.zip https://go.microsoft.com/fwlink/?linkid=2087431 \
+    && wget -progress=bar:force -q -O sqlpackage.zip https://go.microsoft.com/fwlink/?linkid=2113331 \
     && unzip -qq sqlpackage.zip -d /opt/sqlpackage \
     && chmod +x /opt/sqlpackage/sqlpackage
 


### PR DESCRIPTION
# Pull Request Checklist

## Image Details

- [ ] I have added NEW image tags
- [ ] I have made significant changes to existing images

## Pull Request Details

**What this PR does / why we need it**:

The url ``https://go.microsoft.com/fwlink/?linkid=2087431`` gives error "Public access is not permitted on this storage account". I have changed to use same url/SQL version as used for Sitecore 9.3


**Special notes for your reviewer**:

## Pre-submit Checklist

- [ ] I have read and am familiar with the contents of [CONTRIBUTING.md](https://github.com/Sitecore/docker-images/blob/master/CONTRIBUTING.md)
- [ ] I have built the images locally (all relevant OS versions, including Linux if applicable)

  - Include the `.\build.ps1` command used (don't forget to exclude your credentials!):
     - ``pwsh ./Build.ps1 -Topology xm -SitecoreVersion 9.2.0 -InstallSourcePath /mnt/c/Tools/sitecore/ -OSVersion linux``
  - Ensure the build was done on a clean system (`docker system prune -af`)

- [ ] I have updated the `build\CHANGELOG.md` with details about the change(s) included
