### PR TITLE
Updated mkcert to latest version

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Feburary 2023
+
+- [Changed] Updated mkcert.exe to version 1.4.4
+
 ## November 2021
 
 - [Added] CoveoVersion parameter (Specifies which version of Coveo to use and includes it in the build: -CoveoVersion "x.x.x.x")

--- a/build/windows/tests/10.0.x/sitecore-xm1/init.ps1
+++ b/build/windows/tests/10.0.x/sitecore-xm1/init.ps1
@@ -66,8 +66,8 @@ try {
         $mkcert = "mkcert"
     } elseif (-not (Test-Path $mkcert)) {
         Write-Host "Downloading and installing mkcert certificate tool..." -ForegroundColor Green
-        Invoke-WebRequest "https://github.com/FiloSottile/mkcert/releases/download/v1.4.1/mkcert-v1.4.1-windows-amd64.exe" -UseBasicParsing -OutFile mkcert.exe
-        if ((Get-FileHash mkcert.exe).Hash -ne "1BE92F598145F61CA67DD9F5C687DFEC17953548D013715FF54067B34D7C3246") {
+        Invoke-WebRequest "https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-windows-amd64.exe" -UseBasicParsing -OutFile mkcert.exe
+        if ((Get-FileHash mkcert.exe).Hash -ne "D2660B50A9ED59EADA480750561C96ABC2ED4C9A38C6A24D93E30E0977631398") {
             Remove-Item mkcert.exe -Force
             throw "Invalid mkcert.exe file"
         }

--- a/build/windows/tests/10.0.x/sitecore-xp1/init.ps1
+++ b/build/windows/tests/10.0.x/sitecore-xp1/init.ps1
@@ -68,8 +68,8 @@ try {
         $mkcert = "mkcert"
     } elseif (-not (Test-Path $mkcert)) {
         Write-Host "Downloading and installing mkcert certificate tool..." -ForegroundColor Green
-        Invoke-WebRequest "https://github.com/FiloSottile/mkcert/releases/download/v1.4.1/mkcert-v1.4.1-windows-amd64.exe" -UseBasicParsing -OutFile mkcert.exe
-        if ((Get-FileHash mkcert.exe).Hash -ne "1BE92F598145F61CA67DD9F5C687DFEC17953548D013715FF54067B34D7C3246") {
+        Invoke-WebRequest "https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-windows-amd64.exe" -UseBasicParsing -OutFile mkcert.exe
+        if ((Get-FileHash mkcert.exe).Hash -ne "D2660B50A9ED59EADA480750561C96ABC2ED4C9A38C6A24D93E30E0977631398") {
             Remove-Item mkcert.exe -Force
             throw "Invalid mkcert.exe file"
         }


### PR DESCRIPTION
# Pull Request Checklist

## Image Details

- [ ] I have added NEW image tags
- [ ] I have made significant changes to existing images

## Pull Request Details

**What this PR does / why we need it**:
This PR updates the mkcert.exe (which is downloaded as part of Init.ps1), to the (currently) latest version: 1.4.4.

**Which issue(s) this PR fixes**:
Previous version (1.4.1) did not seem to work on my Windows 11 machine, this version does.

## Pre-submit Checklist

- [x] I have read and am familiar with the contents of [CONTRIBUTING.md](https://github.com/Sitecore/docker-images/blob/master/CONTRIBUTING.md)
- [x] I have built the images locally (all relevant OS versions, including Linux if applicable)
- [x] I have added or updated the necessary docker-compose file(s) in the `build/windows/tests` folder
- [x] I have updated the documentation using `build\update-documentation.ps1`
- [x] I have updated the `build\CHANGELOG.md` with details about the change(s) included
